### PR TITLE
fix(session): 换卡 cap 只计写失败触发的轮转;log-only 后停止对死卡重试

### DIFF
--- a/src/cardkit.test.ts
+++ b/src/cardkit.test.ts
@@ -1,8 +1,6 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-
-mock.module('./feishu', () => ({
-  getTenantToken: async () => 'tenant-token',
-}))
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+// 注册共享 ./feishu mock(见该文件头注释:多文件各自 mock 会互相覆盖)
+import './feishu-test-mock'
 
 const cardkit = await import('./cardkit')
 
@@ -88,5 +86,21 @@ describe('cardkit card operations', () => {
     expect(add?.body.type).toBe('insert_before')
     expect(add?.body.target_element_id).toBe('footer')
     expect(JSON.parse(add?.body.elements ?? '[]')).toEqual([element])
+  })
+})
+
+describe('cardkit write-dead card', () => {
+  test('markCardWriteDead makes all subsequent writes no-ops', async () => {
+    cardkit.recordCardCreated('card_wd', 3)
+    cardkit.markCardWriteDead('card_wd')
+
+    await cardkit.addElement('card_wd', { tag: 'markdown', element_id: 'e1', content: 'x' })
+    await cardkit.replaceElement('card_wd', 'footer', { tag: 'markdown', element_id: 'footer', content: 'x' })
+    await cardkit.deleteElement('card_wd', 'e1')
+    await cardkit.patchSettings('card_wd', { config: {} })
+
+    expect(calls.length).toBe(0)
+    expect(cardkit.getElementCount('card_wd')).toBe(3)
+    await cardkit.dispose('card_wd')
   })
 })

--- a/src/cardkit.ts
+++ b/src/cardkit.ts
@@ -41,6 +41,13 @@ interface CardState {
    * would 300313/300121. Per-card and dropped on `dispose`, so a rotated-to
    * fresh card starts clean. */
   deadElements: Set<string>
+  /** Card-level write kill-switch (see markCardWriteDead). Once set, every
+   * write op short-circuits to a resolved promise — no HTTP, no onFailure.
+   * Session flips this when it hits the failure-rotate cap and goes
+   * log-only: without it, the per-second footer ticker and stream handlers
+   * keep hammering the unwritable card (2026-07-04: 663 × code=300308 in
+   * 11 minutes against one dead card). */
+  writeDead?: boolean
   /** Card-level write-failure callback, set by recordCardCreated. Invoked
    * by any cardkit write op that fails even after the streaming-closed
    * reopen+retry; the session uses it to rotate onto a fresh card (see
@@ -111,6 +118,15 @@ export function getElementCount(cardId: string): number {
  * the old card. */
 export function isDeadElement(cardId: string, elementId: string): boolean {
   return cards.get(cardId)?.deadElements.has(elementId) ?? false
+}
+
+/** Stop all future writes to this card. Idempotent; cleared only by
+ * dispose (a rotated-to fresh card has its own state). Covers both new
+ * enqueues and already-queued tasks that haven't reached the wire yet
+ * (each op re-checks the flag when it runs). */
+export function markCardWriteDead(cardId: string): void {
+  state(cardId).writeDead = true
+  cancelSummary(cardId)
 }
 
 function nextSeq(cardId: string): number {
@@ -279,11 +295,13 @@ export function addElement(
   onFailure?: (code?: number) => void,
 ): Promise<void> {
   const s = state(cardId)
+  if (s.writeDead) return Promise.resolve()
   const elementId = (element as { element_id?: string }).element_id
   s.queue = s.queue.then(() => withReopenOnStreamingClosed(
     cardId,
     `addElement`,
     async () => {
+      if (s.writeDead) return
       const seq = nextSeq(cardId)
       await call('POST', `/cards/${cardId}/elements`, {
         type: opts.type ?? 'append',
@@ -314,12 +332,12 @@ export function addElement(
 /** Replace an entire element (used to swap a tool placeholder with its result). */
 export function replaceElement(cardId: string, elementId: string, element: object): Promise<void> {
   const s = state(cardId)
-  if (s.deadElements.has(elementId)) return Promise.resolve()
+  if (s.writeDead || s.deadElements.has(elementId)) return Promise.resolve()
   s.queue = s.queue.then(() => withReopenOnStreamingClosed(
     cardId,
     `replaceElement ${elementId}`,
     async () => {
-      if (s.deadElements.has(elementId)) return
+      if (s.writeDead || s.deadElements.has(elementId)) return
       const seq = nextSeq(cardId)
       await call('PUT', `/cards/${cardId}/elements/${elementId}`, {
         element: JSON.stringify(element),
@@ -333,12 +351,12 @@ export function replaceElement(cardId: string, elementId: string, element: objec
 /** Delete an element by id. */
 export function deleteElement(cardId: string, elementId: string): Promise<void> {
   const s = state(cardId)
-  if (s.deadElements.has(elementId)) return Promise.resolve()
+  if (s.writeDead || s.deadElements.has(elementId)) return Promise.resolve()
   s.queue = s.queue.then(() => withReopenOnStreamingClosed(
     cardId,
     `deleteElement ${elementId}`,
     async () => {
-      if (s.deadElements.has(elementId)) return
+      if (s.writeDead || s.deadElements.has(elementId)) return
       const seq = nextSeq(cardId)
       await call('DELETE', `/cards/${cardId}/elements/${elementId}`, {
         sequence: seq,
@@ -358,6 +376,7 @@ export function deleteElement(cardId: string, elementId: string): Promise<void> 
  * the settings-PATCH endpoint. Whitespace is collapsed and the input
  * is trimmed; empty content is ignored. */
 export function patchSummaryThrottled(cardId: string, content: string): void {
+  if (cards.get(cardId)?.writeDead) return
   const trimmed = (content ?? '').replace(/\s+/g, ' ').trim()
   if (!trimmed) return
   let s = summaryStates.get(cardId)
@@ -402,7 +421,9 @@ export function cancelSummary(cardId: string): void {
  * seq order match the queue order. */
 export function patchSettings(cardId: string, settings: object): Promise<void> {
   const s = state(cardId)
+  if (s.writeDead) return Promise.resolve()
   s.queue = s.queue.then(async () => {
+    if (s.writeDead) return
     try {
       const seq = nextSeq(cardId)
       await call('PATCH', `/cards/${cardId}/settings`, {

--- a/src/feishu-test-mock.ts
+++ b/src/feishu-test-mock.ts
@@ -1,0 +1,57 @@
+/**
+ * 共享的 ./feishu 测试替身(仅供 *.test.ts import)。
+ *
+ * bun 的 mock.module 是进程级注册:多个测试文件各自 mock('./feishu')
+ * 时,后加载的会就地覆盖先加载的 —— cardkit.test.ts 的窄 mock(只有
+ * getTenantToken)曾把 session.test.ts 的全量 mock 顶掉,导致
+ * `bun test src/` 单进程全跑时 Session 构造函数炸
+ * getSessionModelSelection。收敛为这一个模块后,模块缓存保证
+ * mock.module 只注册一次,加载顺序不再影响结果。
+ *
+ * 捕获数组是共享可变状态,测试文件在 beforeEach 里调 resetFeishuMock()。
+ */
+import { mock } from 'bun:test'
+
+export const sentCards: object[] = []
+export const sentTexts: string[] = []
+export const sentRawTexts: string[] = []
+export const deletedReactions: Array<[string, string]> = []
+export const boundResumes: Array<[string, string, string | undefined]> = []
+/** [projects.<name>] 项目 profile 替身,测试往里 set 后 Session 构造时可查到。 */
+export const projectProfiles = new Map<string, { cwd?: string }>()
+
+export function resetFeishuMock(): void {
+  for (const arr of [sentCards, sentTexts, sentRawTexts, deletedReactions, boundResumes]) {
+    arr.length = 0
+  }
+  projectProfiles.clear()
+}
+
+mock.module('./feishu', () => ({
+  PROJECTS_ROOT: '/tmp/lodestar-projects',
+  getSessionResume: () => null,
+  getSessionModelSelection: () => null,
+  getTenantToken: async () => 'tenant-token',
+  preferredChatForSession: new Map(),
+  sendCard: async (_chatId: string, card: object) => {
+    sentCards.push(card)
+    return `om_status_${sentCards.length}`
+  },
+  sendText: async (_chatId: string, text: string) => {
+    sentTexts.push(text)
+    return 'om_text'
+  },
+  sendTextRaw: async (_chatId: string, text: string) => {
+    sentRawTexts.push(text)
+    return 'om_raw'
+  },
+  deleteReaction: async (messageId: string, reactionId: string) => {
+    deletedReactions.push([messageId, reactionId])
+  },
+  bindSessionResume: (sessionName: string, sessionId: string, provider?: string) => {
+    boundResumes.push([sessionName, sessionId, provider])
+  },
+  bindSessionModel: () => {},
+  provisionProject: () => {},
+  projectProfile: (name: string) => projectProfiles.get(name),
+}))

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
-import { localDayKey, logFileForDate, parseLogFileDate, pruneOldLogs } from './log'
+import { fileLoggingEnabled, localDayKey, log, logFileForDate, parseLogFileDate, pruneOldLogs } from './log'
 
 describe('log day key', () => {
   test('localDayKey formats local date as YYYY-MM-DD', () => {
@@ -84,5 +84,28 @@ describe('pruneOldLogs', () => {
     touch(dir, 'daemon-2026-06-17.log') // 8 天前
     touch(dir, 'daemon-2026-06-18.log') // 7 天前
     expect(pruneOldLogs(dir, now)).toBe(2)
+  })
+})
+
+describe('test-env file logging guard', () => {
+  // 跑测试会把 log() 输出写进生产 daemon-*.log(07-02 的 session "probe"
+  // "Claude auth failed" 全是历史测试污染)。bun test 固定设 NODE_ENV=test,
+  // 以此为闸:测试进程只打 stderr,不落盘、不迁移、不清理。
+  test('fileLoggingEnabled gates on NODE_ENV=test', () => {
+    expect(fileLoggingEnabled('test')).toBe(false)
+    expect(fileLoggingEnabled('production')).toBe(true)
+    expect(fileLoggingEnabled('development')).toBe(true)
+    // 显式 undefined 走默认参数(取本进程 env),等价于无参调用;
+    // 本进程就是 bun test,必须已处于禁用态
+    expect(fileLoggingEnabled(undefined)).toBe(false)
+    expect(fileLoggingEnabled()).toBe(false)
+  })
+
+  test('log() under bun test writes stderr only — marker never lands in the real day file', () => {
+    const marker = `log-test-marker-${process.pid}-${Date.now()}`
+    log(marker)
+    const todayFile = logFileForDate(new Date())
+    const content = existsSync(todayFile) ? readFileSync(todayFile, 'utf8') : ''
+    expect(content).not.toContain(marker)
   })
 })

--- a/src/log.ts
+++ b/src/log.ts
@@ -5,7 +5,16 @@ import {
 import { join } from 'node:path'
 import { LOG_FILE, DATA_DIR } from './paths'
 
-try { mkdirSync(DATA_DIR, { recursive: true }) } catch {}
+/** 测试进程(bun test 固定设 NODE_ENV=test)禁止碰生产 DATA_DIR:
+ * 不落盘、不迁移旧日志、不清理 —— 否则跑一遍测试就往真实
+ * daemon-*.log 里塞 session "probe" 噪音,排障时被当成线上故障。 */
+export function fileLoggingEnabled(nodeEnv: string | undefined = process.env.NODE_ENV): boolean {
+  return nodeEnv !== 'test'
+}
+
+if (fileLoggingEnabled()) {
+  try { mkdirSync(DATA_DIR, { recursive: true }) } catch {}
+}
 
 /** 按日日志保留天数(含今天);超过即清理。 */
 const LOG_RETENTION_DAYS = 7
@@ -83,6 +92,7 @@ export function log(msg: string): void {
   const now = new Date()
   const line = `[${now.toISOString()}] ${msg}\n`
   process.stderr.write(line)
+  if (!fileLoggingEnabled()) return
   try {
     const key = localDayKey(now)
     if (lastDayKey !== key) {
@@ -94,5 +104,7 @@ export function log(msg: string): void {
 }
 
 // 启动:先把老 daemon.log 迁移成按日文件,再清理过期日志。
-try { migrateLegacyLogFile() } catch {}
-try { pruneOldLogs(DATA_DIR) } catch {}
+if (fileLoggingEnabled()) {
+  try { migrateLegacyLogFile() } catch {}
+  try { pruneOldLogs(DATA_DIR) } catch {}
+}

--- a/src/session-types.ts
+++ b/src/session-types.ts
@@ -93,15 +93,21 @@ export interface TurnState {
    * don't all queue duplicate rotation attempts. null means "no rotation
    * in flight". */
   rotating: Promise<void> | null
-  /** How many times this turn has rotated to a fresh card. The cap
-   * (MAX_MIDTURN_ROTATES) is enforced ONLY on the reactive failure path
-   * (onCardWriteFailure) — that's the only one that can run away (Feishu
-   * outage, or a poisoned element that fails on every card). The proactive
-   * path (maybeMidTurnRotate) bumps this too but isn't capped: it needs ~50
-   * genuinely-successful elements per card to fire again, so it's naturally
-   * throttled by real output, not by failures. Reset per turn (a fresh
-   * TurnState starts at 0). */
+  /** How many times this turn has rotated to a fresh card, proactive and
+   * reactive combined. Informational (logging) — NOT what the cap reads.
+   * Reset per turn (a fresh TurnState starts at 0). */
   rotateCount: number
+  /** Rotations triggered by the reactive failure path only
+   * (onCardWriteFailure). This is the counter MAX_MIDTURN_ROTATES caps —
+   * the failure path is the only one that can run away (Feishu outage, or
+   * a poisoned element that fails on every card). The proactive path
+   * (maybeMidTurnRotate) deliberately does NOT consume this budget: it
+   * needs ~50 genuinely-successful elements per card to fire again, so
+   * it's naturally throttled by real output. Sharing one counter was the
+   * 2026-07-04 bug — a long turn's 5 legitimate full-card rotations
+   * exhausted the cap, and the next transient 300308 flipped the turn to
+   * log-only. */
+  failureRotateCount: number
   /** Latched once we hit the rotate cap and emit the "giving up" notice,
    * so the notice isn't repeated on every later failed write this turn. */
   rotateGivenUp: boolean

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -1,41 +1,9 @@
 import { EventEmitter } from 'node:events'
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-
-let sentCards: object[] = []
-let sentTexts: string[] = []
-let sentRawTexts: string[] = []
-let deletedReactions: Array<[string, string]> = []
-let boundResumes: Array<[string, string, string | undefined]> = []
-const projectProfiles = new Map<string, { cwd?: string }>()
-
-mock.module('./feishu', () => ({
-  PROJECTS_ROOT: '/tmp/lodestar-projects',
-  getSessionResume: () => null,
-  getSessionModelSelection: () => null,
-  getTenantToken: async () => 'tenant-token',
-  preferredChatForSession: new Map(),
-  sendCard: async (_chatId: string, card: object) => {
-    sentCards.push(card)
-    return `om_status_${sentCards.length}`
-  },
-  sendText: async (_chatId: string, text: string) => {
-    sentTexts.push(text)
-    return 'om_text'
-  },
-  sendTextRaw: async (_chatId: string, text: string) => {
-    sentRawTexts.push(text)
-    return 'om_raw'
-  },
-  deleteReaction: async (messageId: string, reactionId: string) => {
-    deletedReactions.push([messageId, reactionId])
-  },
-  bindSessionResume: (sessionName: string, sessionId: string, provider?: string) => {
-    boundResumes.push([sessionName, sessionId, provider])
-  },
-  bindSessionModel: () => {},
-  provisionProject: () => {},
-  projectProfile: (name: string) => projectProfiles.get(name),
-}))
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  boundResumes, deletedReactions, projectProfiles, resetFeishuMock,
+  sentCards, sentRawTexts, sentTexts,
+} from './feishu-test-mock'
 
 const { Session } = await import('./session')
 const cardkit = await import('./cardkit')
@@ -51,12 +19,7 @@ let calls: FetchCall[] = []
 
 beforeEach(() => {
   calls = []
-  sentCards = []
-  sentTexts = []
-  sentRawTexts = []
-  deletedReactions = []
-  boundResumes = []
-  projectProfiles.clear()
+  resetFeishuMock()
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = new URL(String(input))
     const path = url.pathname.replace('/open-apis/cardkit/v1', '')
@@ -165,6 +128,7 @@ function turnState(cardId = 'card_session_turn'): any {
     footerStatusLabel: null,
     rotating: null,
     rotateCount: 0,
+    failureRotateCount: 0,
     rotateGivenUp: false,
     outboundSeenPaths: new Set(),
     outboundSentPaths: new Set(),
@@ -595,5 +559,71 @@ describe('Session workDir project profile override', () => {
     projectProfiles.set('blankcwd', { cwd: '   ' })
     const session = new Session('blankcwd', 'oc_test_blank')
     expect(session.workDir).toBe('/tmp/lodestar-projects/blankcwd')
+  })
+})
+
+describe('Session rotate cap counts only failure-triggered rotations', () => {
+  // 2026-07-04 03:46 事故:turn 2 里 5 次正常满卡轮转(elementCount=50)把
+  // rotateCount 耗光,第 2 次真实写失败(300308)一来就撞 cap 放弃。cap 的
+  // 设计意图(session-types.ts)是只约束失败路径 —— 主动满卡轮转被真实输出
+  // 天然节流,不该消耗失败额度。
+  test('proactive full-card rotations do not consume the failure cap', async () => {
+    const session = new Session('probe', 'chat_id') as any
+    session.proc = new FakeAgentProc('claude', 'claude-session-1')
+    const turn = turnState('card_old')
+    turn.userOpenId = ''
+    session.currentTurn = turn
+    cardkit.recordCardCreated('card_old', 1)
+    turn.rotateCount = 5 // 5 次主动满卡轮转已发生,但从未因写失败换过卡
+
+    try {
+      session.onCardWriteFailure(300308)
+
+      expect(turn.rotateGivenUp).toBe(false)
+      expect(turn.rotating).not.toBeNull()
+      await turn.rotating
+      expect(turn.cardId).not.toBe('card_old') // 真的换到了新卡
+    } finally {
+      session.stopFooterStatus(turn)
+      await cardkit.dispose(turn.cardId)
+    }
+  })
+
+  test('give-up stops the footer ticker, blocks its restart, and kills card writes', async () => {
+    const session = new Session('probe', 'chat_id') as any
+    session.proc = new FakeAgentProc('claude', 'claude-session-1')
+    const turn = turnState('card_dead')
+    turn.userOpenId = ''
+    session.currentTurn = turn
+    cardkit.recordCardCreated('card_dead', 1)
+    turn.failureRotateCount = 5 // 失败额度已耗尽
+
+    try {
+      session.startWritingFooter(turn)
+      expect(turn.footerStatusHandle).not.toBeNull()
+
+      session.onCardWriteFailure(300308)
+
+      expect(turn.rotateGivenUp).toBe(true)
+      expect(turn.rotating).toBeNull() // 不再尝试换卡
+      // 事故根因 1:log-only 后 footer 每秒 ticker 没停,对死卡刷了 11 分钟
+      // 663 条 300308。放弃时必须停表,且 phase 切换不能把它拉起来。
+      expect(turn.footerStatusHandle).toBeNull()
+      session.startWorkingFooter(turn)
+      expect(turn.footerStatusHandle).toBeNull()
+      // log-only 语义:本轮剩余对该卡的写全部短路,不再打飞书。
+      const before = calls.length
+      await cardkit.replaceElement('card_dead', 'footer', { tag: 'markdown', element_id: 'footer', content: 'x' })
+      await cardkit.addElement('card_dead', { tag: 'markdown', element_id: 'e_new', content: 'x' })
+      expect(calls.length).toBe(before)
+      // 告警文案说的是真实语义(换卡耗尽),不是「连续 N 次写入失败」
+      expect(sentRawTexts.length).toBe(1)
+      expect(sentRawTexts[0]).toContain('换卡')
+      expect(sentRawTexts[0]).toContain('仅日志可见')
+      expect(sentRawTexts[0]).not.toContain('连续 5 次写入失败')
+    } finally {
+      session.stopFooterStatus(turn)
+      await cardkit.dispose('card_dead')
+    }
   })
 })

--- a/src/session.ts
+++ b/src/session.ts
@@ -2040,6 +2040,7 @@ export class Session {
       footerStatusLabel: null,
       rotating: null,
       rotateCount: 0,
+      failureRotateCount: 0,
       rotateGivenUp: false,
       outboundSeenPaths: new Set(),
       outboundSentPaths: new Set(),
@@ -2088,16 +2089,21 @@ export class Session {
     const turn = this.currentTurn
     if (!turn) return
     if (turn.rotating) return
-    if (turn.rotateCount >= MAX_MIDTURN_ROTATES) {
-      if (!turn.rotateGivenUp) {
-        turn.rotateGivenUp = true
-        log(`session "${this.sessionName}": rotate cap (${MAX_MIDTURN_ROTATES}) hit — giving up, rest of turn is log-only`)
-        void feishu.sendTextRaw(this.chatId, `⚠️ 卡片连续 ${MAX_MIDTURN_ROTATES} 次写入失败(疑似飞书故障或内容超限),本轮后续输出仅日志可见。`)
-      }
+    if (turn.rotateGivenUp) return
+    if (turn.failureRotateCount >= MAX_MIDTURN_ROTATES) {
+      turn.rotateGivenUp = true
+      // log-only 要名副其实:停掉每秒 footer 计时器,并把当前卡整卡标记
+      // 拒写,否则 ticker + stream handler 会对着死卡刷到 turn 结束
+      // (2026-07-04:11 分钟 663 条 300308)。
+      this.stopFooterStatus(turn)
+      cardkit.markCardWriteDead(turn.cardId)
+      log(`session "${this.sessionName}": failure-rotate cap (${MAX_MIDTURN_ROTATES}) hit — giving up, rest of turn is log-only`)
+      void feishu.sendTextRaw(this.chatId, `⚠️ 卡片写入失败已触发 ${MAX_MIDTURN_ROTATES} 次换卡仍未恢复(疑似飞书故障或元素超限),本轮后续输出仅日志可见。`)
       return
     }
     const why = cardkit.isElementLimitCode(code) ? `element limit (${code})` : `write failure (code=${code ?? 'n/a'})`
     log(`session "${this.sessionName}": ${why} on card=${turn.cardId.slice(0, 8)}… — rotating to fresh card`)
+    turn.failureRotateCount++
     this.startMidTurnRotate(turn)
   }
 
@@ -2535,6 +2541,9 @@ export class Session {
    * element and uses replaceElement so status updates appear immediately
    * instead of invoking Feishu's typewriter. */
   private startFooterStatus(turn: TurnState, status: string): void {
+    // log-only 之后 phase 切换(Thinking/Writing/Working)不许把每秒
+    // ticker 重新拉起来 —— 卡已标记拒写,计时纯属空转。
+    if (turn.rotateGivenUp) return
     if (turn.footerStatusHandle && turn.footerStatusLabel === status) return
     this.stopFooterStatus(turn)
     turn.footerStatusLabel = status

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 
 export interface WorktreeEntry {
@@ -209,7 +209,10 @@ export function assertProjectWorktreeClean(projectDir: string, projectName: stri
 function assertGitRepo(projectDir: string): void {
   if (!existsSync(projectDir)) throw new Error(`project directory does not exist: ${projectDir}`)
   const top = git(projectDir, ['rev-parse', '--show-toplevel']).trim()
-  if (resolve(top) !== resolve(projectDir)) {
+  // realpath 两边再比:git 返回的是解掉符号链接的真实路径,而传入的
+  // projectDir 可能带符号链接段(macOS /var → /private/var,tmpdir 下
+  // 的测试仓库全踩这个),lexical resolve 会把同一目录判成两个。
+  if (realpathSync(top) !== realpathSync(projectDir)) {
     throw new Error(`${projectDir} is not the git repository root (${top})`)
   }
 }


### PR DESCRIPTION
## 背景

2026-07-04 生产环境事故:一个长 turn(约 2 小时)先后发生 6 次 mid-turn 换卡,其中 5 次是**正常满卡轮转**(elementCount=50 触发软上限),只有 1 次是写失败(飞书 cardkit `300308 Server Internal Error`)触发。第二次瞬时 300308 到来时,共享的 `rotateCount` 已被正常轮转耗光,直接撞 cap 放弃转 log-only;此后 footer 每秒 ticker 没有停止,对已放弃的卡片连续重试 **11 分钟、刷出 663 条 300308 错误日志**,并向群里发出误导性的「卡片连续 5 次写入失败」告警。

`session-types.ts` 中 `rotateCount` 的注释本来就写明 cap 只应约束失败路径("The proactive path bumps this too but isn't capped"),但实现里两条路径共用一个计数器,主动轮转会消耗失败额度 —— 本 PR 使实现与设计意图一致。

## 变更

**commit 1 — 换卡 cap 语义修正 + log-only 止血**
- `TurnState` 拆出 `failureRotateCount`,`MAX_MIDTURN_ROTATES` 只对写失败触发的轮转生效;正常满卡轮转被真实输出天然节流,不再消耗失败额度
- 撞 cap 时:`stopFooterStatus` 停掉每秒 footer 计时器(且 `startFooterStatus` 在 `rotateGivenUp` 后拒绝因 phase 切换重启);新增 `cardkit.markCardWriteDead(cardId)` 把当前卡整卡标记拒写(含已入队未执行的任务),log-only 名副其实
- 告警文案改为真实语义:「卡片写入失败已触发 N 次换卡仍未恢复」
- 测试:抽出共享 `feishu-test-mock.ts`,消除多测试文件各自 `mock.module('./feishu')` 互相覆盖导致 `bun test src/` 单进程全跑失败的问题

**commit 2 — 测试卫生 + worktree 路径修复**
- `log.ts`:`NODE_ENV=test`(bun test 固定设置)时 `log()` 只打 stderr,不写生产 `daemon-*.log`、不迁移、不清理 —— 此前跑一遍测试就会往真实日志里塞 `session "probe"` 噪音,排障时被当成线上故障
- `worktree.ts`:`assertGitRepo` 改用 `realpathSync` 比较,修复 macOS `/var → /private/var` 符号链接导致同一目录被判非仓库根 —— `worktree.test.ts` 的 10 个用例在 macOS 上因此常年失败,本 PR 后全绿

## 测试

- 分支上 `bun test src/`:**233 pass / 0 fail**(含 5 个新增用例,其中一个完整复现事故状态:`rotateCount=5, failureRotateCount=0` 时来一次 300308,现在正常换卡而不是放弃)
- 修复已在生产 daemon 运行验证(写失败换卡、log-only 拒写、日志零污染)
