### PR TITLE
feat(claude): [claude] bin 显式指定 Claude Code 可执行文件(接入 reclaude 等包装器)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ lodestar-setup
 
 `task` 面板里的 `删` 会二次确认,确认后删除整个清单和清单内任务。这个能力需要飞书应用开通任务清单/任务/评论相关权限;缺权限时面板会显示 Open API 返回的失败原因和缺失 scope。
 
+### 🔀 自定义 Claude Code 可执行文件(reclaude 等)
+
+默认自动查找 `claude`(`~/.local/npm-global/bin` → `~/.local/bin` → PATH,都没有则用 SDK 自带二进制)。要换成 [reclaude](https://docs.reclaude.ai) 这类"参数原样透传给 claude"的包装器,在 `config.toml` 显式指定:
+
+```toml
+[claude]
+bin = "~/.local/bin/reclaude"
+```
+
+配置后跳过自动查找;路径不存在会在会话启动时直接报错,不会静默回退。日志里 `executable=config:<路径>` 可确认生效。
+
+迁移到 reclaude 时注意:`[claude.env]` 或 `~/.claude/settings.json` 里遗留的 GLM `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` 必须清掉 —— base URL 指向 GLM 时流量不经官方域名,reclaude 的拦截不会生效,烧的还是 GLM 额度。`[claude.models.*]` 里的 GLM profile 也需换回官方模型档位。
+
 ### 🔔 HTTP 通知端点
 
 本机任何脚本一行 curl 就能往群里推一张 markdown 卡片(info / warn / error 三档染色):

--- a/docs/claude-agent-backend.md
+++ b/docs/claude-agent-backend.md
@@ -42,6 +42,8 @@ haiku = "v4flash"
 
 模型路由的真相源是 `~/.claude/settings.json`(SDK 经 `settingSources:['user']` 读取):`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_DEFAULT_OPUS_MODEL` 等都在那里配。Lodestar 不再注入这些 env,`[claude.env]` 仅作可选 escape hatch。
 
+可执行文件解析:`resolveClaudeExecutableConfig()` 默认自动查找 `claude`(`~/.local/npm-global/bin` → `~/.local/bin` → PATH → SDK 自带)。`config.toml` 设 `[claude].bin`(支持 `~`)可显式覆盖,用于 reclaude 这类参数透传包装器;路径不存在时 `sendInitialize` 直接抛错,不静默回退。日志 `executable=config:<路径>` 确认生效。
+
 主线程 SDK `model` 不直传 `5.2` / `v4pro` 这类上游模型代码,而是传 `opus` 档位 alias,Claude Code 再按 settings.json 的 `ANTHROPIC_DEFAULT_*_MODEL` 路由。实际 smoke 证明直传 `5.2` 会返回 “模型不存在”。
 
 ## Claude Event Mapping

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -95,6 +95,53 @@ describe('Claude model profiles', () => {
   })
 })
 
+describe('Claude configured executable ([claude] bin)', () => {
+  test('uses configured bin as the SDK executable', () => {
+    const bin = '/home/me/.local/bin/reclaude'
+    const executable = resolveClaudeExecutableConfig({
+      platform: 'linux',
+      configuredBin: bin,
+      exists: path => path === bin,
+    })
+
+    expect(executable.pathToClaudeCodeExecutable).toBe(bin)
+    expect(executable.spawnClaudeCodeProcess).toBeUndefined()
+    expect(executable.description).toBe(`config:${bin}`)
+  })
+
+  test('throws instead of silently falling back when configured bin is missing', () => {
+    expect(() => resolveClaudeExecutableConfig({
+      platform: 'linux',
+      configuredBin: '/nope/reclaude',
+      exists: () => false,
+    })).toThrow('/nope/reclaude')
+  })
+
+  test('runs configured Windows .cmd bin through the shell shim spawn hook', () => {
+    const bin = win32.join('C:\\Users\\me\\bin', 'reclaude.cmd')
+    const executable = resolveClaudeExecutableConfig({
+      platform: 'win32',
+      configuredBin: bin,
+      exists: path => path === bin,
+    })
+
+    expect(executable.pathToClaudeCodeExecutable).toBe(bin)
+    expect(typeof executable.spawnClaudeCodeProcess).toBe('function')
+    expect(executable.description).toBe(`windows-shell-shim:${bin}`)
+  })
+
+  test('explicit null configuredBin falls back to auto discovery', () => {
+    const executable = resolveClaudeExecutableConfig({
+      platform: 'win32',
+      pathEnv: '',
+      configuredBin: null,
+      exists: () => false,
+    })
+
+    expect(executable).toEqual({ description: 'sdk-default' })
+  })
+})
+
 describe('Claude permission mode', () => {
   test('runs Claude Code in bypass permission mode', () => {
     expect(CLAUDE_PERMISSION_MODE).toBe('bypassPermissions')

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -28,6 +28,7 @@ const {
 const {
   resolveClaudeSdkModel,
 } = await import('./claude-models')
+const { config } = await import('./config')
 
 // context window max 是 daemon 全局缓存(按路由 key 跨 session 共享),
 // 每个用例前重置,避免互相污染。
@@ -139,6 +140,33 @@ describe('Claude configured executable ([claude] bin)', () => {
     })
 
     expect(executable).toEqual({ description: 'sdk-default' })
+  })
+
+  test('sendInitialize 配错 bin 路径时走 error/exit 事件而非同步抛出', () => {
+    // [claude].bin 指向不存在的路径 → resolveClaudeExecutableConfig 同步抛出;
+    // 修复确保该抛出在 sendInitialize 的 try/catch 内被捕获,转为事件输出,
+    // 调用方不会收到同步异常,session 层可通过 error/exit 事件做正常清理。
+    ;(config.claude as any).bin = '/nope/reclaude'
+    try {
+      const proc = new ClaudeAgentProcess({ workDir: '/tmp', effort: 'high' })
+      const errors: Error[] = []
+      const exits: any[] = []
+      proc.on('error', (err: Error) => errors.push(err))
+      proc.on('exit', (ev: any) => exits.push(ev))
+
+      // 不能同步抛出
+      expect(() => proc.sendInitialize()).not.toThrow()
+
+      // error 事件携带路径信息
+      expect(errors).toHaveLength(1)
+      expect(errors[0].message).toContain('/nope/reclaude')
+
+      // exit 事件 code=1
+      expect(exits).toHaveLength(1)
+      expect(exits[0].code).toBe(1)
+    } finally {
+      delete (config.claude as any).bin
+    }
   })
 })
 

--- a/src/claude-agent-process.ts
+++ b/src/claude-agent-process.ts
@@ -658,8 +658,6 @@ export class ClaudeAgentProcess extends EventEmitter {
     if (this.started) return
     this.started = true
     const model = resolveClaudeSdkModel(this.opts.model)
-    const executable = resolveClaudeExecutableConfig()
-    log(`claude-agent-process: spawn SDK query model=${model ?? 'default'} effort=${this.opts.effort} cwd=${this.opts.workDir} executable=${executable.description}`)
     const profile = this.opts.profile
     if (profile) {
       log(`claude-agent-process: project profile active — settingSources=${profile.settingSources ?? '-'} strictMcp=${profile.strictMcp ?? false} tools=${profile.tools ?? '-'} loadProjectMcp=${profile.loadProjectMcp ?? false} keepInstructions=${(profile.keepLodestarInstructions ?? true)}`)
@@ -672,6 +670,10 @@ export class ClaudeAgentProcess extends EventEmitter {
     // Lodestar's appended card/output markers for a fully isolated agent.
     const appendSystemPrompt = profile?.keepLodestarInstructions === false ? undefined : this.opts.appendSystemPrompt
     try {
+      // resolveClaudeExecutableConfig 在 [claude].bin 配错路径时同步抛出;
+      // 必须在 try 内调用,确保错误走 error/exit 事件而非穿透到调用方。
+      const executable = resolveClaudeExecutableConfig()
+      log(`claude-agent-process: spawn SDK query model=${model ?? 'default'} effort=${this.opts.effort} cwd=${this.opts.workDir} executable=${executable.description}`)
       this.query = query({
         prompt: this.input,
         options: {

--- a/src/claude-agent-process.ts
+++ b/src/claude-agent-process.ts
@@ -96,6 +96,8 @@ type ClaudePathLookup = {
   pathEnv?: string
   homeDir?: string
   exists?: (path: string) => boolean
+  /** undefined = 读 config.claude.bin;显式 null = 视为未配置(测试隔离 config 用)。 */
+  configuredBin?: string | null
 }
 
 type ClaudeExecutableConfig = {
@@ -165,6 +167,23 @@ export function assertClaudeCodeAvailable(): void {
 
 export function resolveClaudeExecutableConfig(lookup: ClaudePathLookup = {}): ClaudeExecutableConfig {
   const platform = lookup.platform ?? process.platform
+  const configured = lookup.configuredBin === undefined ? config.claude.bin : lookup.configuredBin
+  if (configured) {
+    const exists = lookup.exists ?? existsSync
+    // [claude].bin 配错时必须 fail fast:静默回退会让用户以为在烧包装器
+    // (如 reclaude)的额度,实际走了别的 key。
+    if (!exists(configured)) {
+      throw new Error(`lodestar: [claude].bin not found: ${configured} (config.toml)`)
+    }
+    if (platform === 'win32' && windowsShellShim(configured)) {
+      return {
+        pathToClaudeCodeExecutable: configured,
+        spawnClaudeCodeProcess: spawnWindowsShellShim,
+        description: `windows-shell-shim:${configured}`,
+      }
+    }
+    return { pathToClaudeCodeExecutable: configured, description: `config:${configured}` }
+  }
   const bin = findClaudeBin(lookup)
   if (!bin) return { description: 'sdk-default' }
   if (platform === 'win32' && windowsShellShim(bin)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,9 @@ export interface LodestarConfig {
    * `@anthropic-ai/claude-agent-sdk`. Empty record = inherit the user's
    * local Claude Code configuration. */
   claude: {
+    /** 显式指定 SDK spawn 的 Claude Code 可执行文件(如 reclaude 这类
+     * 参数透传包装器)。未设置 = 自动查找。 */
+    bin?: string
     env: Record<string, string>
     models: Record<string, ClaudeModelConfig>
   }
@@ -197,12 +200,13 @@ function loadConfig(): LodestarConfig {
   // [codex.env] / [claude.env] 节可选 —— 空 record 就维持各 CLI 自己的登录态。
   const codexEnv = envSection('codex.env')
   const claudeEnv = envSection('claude.env')
+  const claudeBin = t.claude?.bin ? expandTilde(t.claude.bin) : undefined
   return {
     feishu: { app_id: appId, app_secret: appSecret },
     runtime: { projects_root: projectsRoot },
     notify: { bind: notifyBind, port: notifyPort },
     codex: { env: codexEnv },
-    claude: { env: claudeEnv, models: claudeModelSections() },
+    claude: { bin: claudeBin, env: claudeEnv, models: claudeModelSections() },
     projects: projectSections(),
   }
 }


### PR DESCRIPTION
## 动机

接入 [reclaude](https://docs.reclaude.ai) 这类「参数原样透传给 claude」的包装器时,需要让 Lodestar 启动指定的可执行文件而不是自动查找到的 `claude`。

## 变更

- `config.toml` 新增 `[claude] bin`(支持 `~` 展开):配置后跳过自动查找,直接作为 `pathToClaudeCodeExecutable` 传给 SDK;Windows shell shim(`.cmd`/`.ps1`)沿用现有 `spawnClaudeCodeProcess` 兼容处理
- **fail-fast**:路径不存在时会话启动直接报错,不静默回退 —— 静默回退会让用户以为在烧包装器的额度,实际走了别的 key;错误经 `try/catch` 走 `error`/`exit` 事件而非同步穿透到调用方(第二个 commit)
- 日志 `executable=config:<路径>` 可确认生效;未配置时行为完全不变(自动查找 `~/.local/npm-global/bin` → `~/.local/bin` → PATH → SDK 自带)
- README 与 `docs/claude-agent-backend.md` 补充配置说明与迁移注意事项

## 测试

- 新增 claude-agent-process 用例覆盖:显式 bin、bin 不存在报错、未配置回退自动查找、Windows shim;分支上该文件 **35 pass / 0 fail**
- 分支全量的 10 个 `project worktrees` 失败是上游在 macOS 上已存在的符号链接路径比较问题(`/var → /private/var`),与本 PR 无关,由另一个 PR(fix/card-write-failure-hardening)修复
