### PR TITLE
fix(session): 后台任务恢复轮开卡,assistant 正文不再静默丢弃

### DIFF
--- a/src/cards/turn.ts
+++ b/src/cards/turn.ts
@@ -237,12 +237,14 @@ interface MainCardOpts {
   model?: string
   effort?: string
   /** What started this turn:
-   *   'user_message' — user input batch(panel "📥 收到 (N)" 渲染原文)
-   *   'card_full'    — 同一 Codex turn 的"续卡":前一张卡写满(element 数
-   *                   触顶 ~75)或写入被飞书拒,session rotate 出来的新卡
-   *                   (banner `📨 接续上一张`,无 panel,turn 号跟旧卡
-   *                   相同) */
-  kind?: 'user_message' | 'card_full'
+   *   'user_message'   — user input batch(panel "📥 收到 (N)" 渲染原文)
+   *   'card_full'      — 同一 Codex turn 的"续卡":前一张卡写满(element 数
+   *                     触顶 ~75)或写入被飞书拒,session rotate 出来的新卡
+   *                     (banner `📨 接续上一张`,无 panel,turn 号跟旧卡
+   *                     相同)
+   *   'bg_task_resume' — 后台任务结算后 SDK 自发的恢复轮(无用户消息,
+   *                     banner `🔁 后台任务完成`,无 panel) */
+  kind?: 'user_message' | 'card_full' | 'bg_task_resume'
   /** 本轮 Codex 收到的 user wireText 列表。boot turn 通常是 1 条;mid-turn
    * 用户连发的 N 条会在下一 turn 一并塞进。空数组 / undefined 时不渲染
    * userInput panel。 */
@@ -262,7 +264,9 @@ export function mainConversationCard(opts: MainCardOpts): object {
   const providerLabel = opts.provider === 'claude' ? 'Claude' : 'Codex'
   const banner = opts.kind === 'card_full'
     ? [{ tag: 'markdown', content: `📨 接续上一张（同一轮 ${providerLabel}，前卡写满或写入受限）` }]
-    : []
+    : opts.kind === 'bg_task_resume'
+      ? [{ tag: 'markdown', content: `🔁 后台任务完成，${providerLabel} 继续处理结果 #${opts.turn}` }]
+      : []
   const inputs = opts.userInputs ?? []
   const userInputHeader = `📥 收到 (${inputs.length}) ${opts.directStart ? '🚀' : `#${opts.turn}`}`
   const userInputPanel = inputs.length > 0

--- a/src/feishu-test-mock.ts
+++ b/src/feishu-test-mock.ts
@@ -17,11 +17,12 @@ export const sentTexts: string[] = []
 export const sentRawTexts: string[] = []
 export const deletedReactions: Array<[string, string]> = []
 export const boundResumes: Array<[string, string, string | undefined]> = []
+export const urgentPushes: Array<[string, string[]]> = []
 /** [projects.<name>] 项目 profile 替身,测试往里 set 后 Session 构造时可查到。 */
 export const projectProfiles = new Map<string, { cwd?: string }>()
 
 export function resetFeishuMock(): void {
-  for (const arr of [sentCards, sentTexts, sentRawTexts, deletedReactions, boundResumes]) {
+  for (const arr of [sentCards, sentTexts, sentRawTexts, deletedReactions, boundResumes, urgentPushes]) {
     arr.length = 0
   }
   projectProfiles.clear()
@@ -47,6 +48,9 @@ mock.module('./feishu', () => ({
   },
   deleteReaction: async (messageId: string, reactionId: string) => {
     deletedReactions.push([messageId, reactionId])
+  },
+  urgentApp: async (messageId: string, openIds: string[]) => {
+    urgentPushes.push([messageId, openIds])
   },
   bindSessionResume: (sessionName: string, sessionId: string, provider?: string) => {
     boundResumes.push([sessionName, sessionId, provider])

--- a/src/session-types.ts
+++ b/src/session-types.ts
@@ -15,8 +15,11 @@ export interface TurnState {
    * urgent_app push so only the initiator gets pinged (in case there
    * are other members in the group). Empty string → skip the ping. */
   userOpenId: string
-  /** What kicked off this turn. Kept explicit for turn lifecycle logic. */
-  trigger: 'user_message'
+  /** What kicked off this turn. Kept explicit for turn lifecycle logic.
+   *   'user_message'   — 用户消息批次
+   *   'bg_task_resume' — 后台任务结算后 SDK 自发的恢复轮(无用户消息;
+   *                      不开卡的话整轮正文会被丢弃) */
+  trigger: 'user_message' | 'bg_task_resume'
   toolCount: number
   /** `output` / `isError` are filled in by completeTool and kept so
    * card rotation can rebuild unfinished or failed tool panels. */

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -2,11 +2,13 @@ import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
   boundResumes, deletedReactions, projectProfiles, resetFeishuMock,
-  sentCards, sentRawTexts, sentTexts,
+  sentCards, sentRawTexts, sentTexts, urgentPushes,
 } from './feishu-test-mock'
 
 const { Session } = await import('./session')
 const cardkit = await import('./cardkit')
+const { fixedModelChoices, normalizeFixedModelSelection } = await import('./session-model')
+const { config } = await import('./config')
 
 interface FetchCall {
   method: string
@@ -625,5 +627,231 @@ describe('Session rotate cap counts only failure-triggered rotations', () => {
       session.stopFooterStatus(turn)
       await cardkit.dispose('card_dead')
     }
+  })
+})
+
+describe('Session SDK-initiated bg-task resume turns', () => {
+  // 2026-07-04 事故:reviewer 后台 agent 完成 → SDK 自发恢复轮(init 无用户
+  // 消息)合并出终报告,但 init handler 因 pendingUserMessageCount=0 不开卡,
+  // appendAssistant 无 currentTurn 直接丢字 —— 6.6KB 终报告只存在于
+  // transcript,飞书全程无痕。恢复轮必须开卡;开不了卡也必须纯文本兜底。
+  async function waitFor(cond: () => boolean, ms = 2000): Promise<void> {
+    const t0 = Date.now()
+    while (!cond()) {
+      if (Date.now() - t0 > ms) throw new Error('waitFor timeout')
+      await new Promise(resolve => setTimeout(resolve, 5))
+    }
+  }
+
+  function emitClaudeResult(proc: any): void {
+    proc.lastResult = {
+      cost_usd: null,
+      cost_delta_usd: null,
+      duration_ms: 1000,
+      num_turns: 1,
+      usage: null,
+      subtype: 'success',
+      is_error: false,
+    }
+    proc.emit('result', {})
+  }
+
+  function wiredClaudeSession(): { session: any; proc: any } {
+    const session = new Session('probe', 'chat_id') as any
+    const proc = new FakeAgentProc('claude', 'claude-session-1')
+    session.proc = proc
+    session.selectedProvider = 'claude'
+    session.lastUserOpenId = 'ou_user'
+    session.wireProc(proc)
+    proc.emit('init', { session_id: 'claude-session-1' }) // boot init,无用户批次,不开卡
+    return { session, proc }
+  }
+
+  test('settle 后的自发 init 开 bg_task_resume 卡,终报告落卡、正常收尾并加急推送', async () => {
+    const { session, proc } = wiredClaudeSession()
+    expect(session.currentTurn).toBeNull()
+
+    proc.emit('bg_task_settled', { task_id: 't1', status: 'completed' })
+    proc.emit('init', { session_id: 'claude-session-1' }) // SDK 自发恢复轮
+    await waitFor(() => session.currentTurn !== null)
+
+    try {
+      expect(session.currentTurn.trigger).toBe('bg_task_resume')
+      expect(session.status).toBe('working')
+
+      proc.emit('assistant_text', { text: '双盲 review 合并终报告' })
+      proc.emit('assistant_block_stop', {})
+      emitClaudeResult(proc)
+      await waitFor(() => session.currentTurn === null)
+      // closeTurnCard 是 fire-and-forget:等终态 settings patch 落地再断言
+      await waitFor(() => calls.some(c => c.method === 'PATCH' && c.path.includes('/settings')))
+
+      const wroteReport = calls.some(c =>
+        c.method === 'POST' &&
+        /\/cards\/[^/]+\/elements$/.test(c.path) &&
+        String(c.body?.elements ?? '').includes('终报告'),
+      )
+      expect(wroteReport).toBe(true)
+      expect(session.status).toBe('idle')
+      expect(urgentPushes.length).toBe(1)
+      expect(sentTexts).toEqual([]) // 走了卡,不该触发纯文本兜底
+    } finally {
+      if (session.currentTurn) {
+        session.stopFooterStatus(session.currentTurn)
+        await cardkit.dispose(session.currentTurn.cardId)
+      }
+    }
+  })
+
+  test('开卡窗口期先到的 assistant 文本并入新卡,不丢', async () => {
+    const { session, proc } = wiredClaudeSession()
+
+    proc.emit('bg_task_settled', { task_id: 't1', status: 'completed' })
+    proc.emit('init', { session_id: 'claude-session-1' })
+    // openTurnCard 还在 await sendCard/id_convert,文本已经开始流 —— 事故里
+    // 55ms 后模型就开写。这些字必须并入随后落地的卡。
+    proc.emit('assistant_text', { text: '窗口期先到的段落' })
+    proc.emit('assistant_block_stop', {})
+    await waitFor(() => session.currentTurn !== null)
+
+    try {
+      emitClaudeResult(proc)
+      await waitFor(() => session.currentTurn === null)
+      await waitFor(() => calls.some(c => c.method === 'PATCH' && c.path.includes('/settings')))
+
+      const wrote = calls.some(c =>
+        c.method === 'POST' &&
+        /\/cards\/[^/]+\/elements$/.test(c.path) &&
+        String(c.body?.elements ?? '').includes('窗口期先到的段落'),
+      )
+      expect(wrote).toBe(true)
+    } finally {
+      if (session.currentTurn) {
+        session.stopFooterStatus(session.currentTurn)
+        await cardkit.dispose(session.currentTurn.cardId)
+      }
+    }
+  })
+
+  test('没有 settle 的空 init 不开卡(probe/模型切换等场景不受影响)', async () => {
+    const { session, proc } = wiredClaudeSession()
+
+    proc.emit('init', { session_id: 'claude-session-1' }) // 无 settle、无用户批次
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(session.currentTurn).toBeNull()
+    expect(sentCards.length).toBe(0)
+  })
+
+  test('恢复轮开卡失败(id_convert 报错)时,输出纯文本兜底不丢', async () => {
+    const { session, proc } = wiredClaudeSession()
+    // 让本轮 id_convert 报错 → openTurnCard 拿不到 cardId → 开卡失败。
+    const base = globalThis.fetch
+    globalThis.fetch = (async (input: any, init?: any) => {
+      const url = new URL(String(input))
+      if (url.pathname.endsWith('/cards/id_convert')) {
+        return new Response(JSON.stringify({ code: 99, msg: 'boom' }), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return base(input, init)
+    }) as typeof fetch
+
+    try {
+      proc.emit('bg_task_settled', { task_id: 't1', status: 'completed' })
+      proc.emit('init', { session_id: 'claude-session-1' })
+      // 开卡在 await 中就会失败;这些字必须仍被兜住(开卡窗口 + cardless 续窗)。
+      proc.emit('assistant_text', { text: '孤儿终报告内容' })
+      proc.emit('assistant_block_stop', {})
+      await waitFor(() => session.bgResumeCardless === true || session.currentTurn !== null)
+      emitClaudeResult(proc)
+      await waitFor(() => sentTexts.length > 0)
+
+      expect(sentTexts.join('\n')).toContain('孤儿终报告内容')
+      expect(session.currentTurn).toBeNull()
+    } finally {
+      globalThis.fetch = base
+    }
+  })
+
+  test('用户打断后,残留的 post-interrupt 正文被丢弃,不推送 📄 兜底消息', async () => {
+    const session = new Session('probe', 'chat_id') as any
+    const proc = new FakeAgentProc('claude', 'claude-session-1')
+    session.proc = proc
+    session.selectedProvider = 'claude'
+    session.wireProc(proc)
+    const turn = turnState('card_live')
+    turn.userOpenId = ''
+    session.currentTurn = turn
+    cardkit.recordCardCreated('card_live', 1)
+
+    try {
+      // 模拟软停止:置 userInterrupted、封口卡片(currentTurn 置空)。
+      session.userInterrupted = true
+      await session.closeTurnCard('🛑 打断')
+      expect(session.currentTurn).toBeNull()
+
+      // interrupt 落地前 SDK 仍在流式:这些 delta 到达时已无卡。旧行为是
+      // 静默丢弃 —— 修复后必须仍然丢弃,不能变成 📄 纯文本兜底。
+      proc.emit('assistant_text', { text: '被取消的轮次尾巴' })
+      proc.emit('assistant_block_stop', {})
+      emitClaudeResult(proc)
+      await new Promise(resolve => setTimeout(resolve, 30))
+
+      expect(sentTexts.join('\n')).not.toContain('被取消的轮次尾巴')
+      expect(sentTexts.some(t => t.includes('📄'))).toBe(false)
+      expect(session.status).toBe('idle')
+    } finally {
+      session.stopFooterStatus(turn)
+      await cardkit.dispose('card_live')
+    }
+  })
+
+  test('result 抢在 bg-resume 开卡 await 窗口内到达:不重复兜底,卡片正常收尾,不卡在 working', async () => {
+    const { session, proc } = wiredClaudeSession()
+
+    proc.emit('bg_task_settled', { task_id: 't1', status: 'completed' })
+    proc.emit('init', { session_id: 'claude-session-1' }) // 开始开卡(await sendCard/id_convert)
+    proc.emit('assistant_text', { text: '短恢复轮输出' })
+    proc.emit('assistant_block_stop', {})
+    // 开卡还没落地(openingTurn 仍 true)就来 result —— 竞态窗口。
+    emitClaudeResult(proc)
+
+    await waitFor(() => session.currentTurn === null && session.openingTurn === false)
+    await waitFor(() => calls.some(c => c.method === 'PATCH' && c.path.includes('/settings')))
+
+    // 文本进了卡(不是纯文本兜底),且只出现一次。
+    expect(sentTexts.some(t => t.includes('📄'))).toBe(false)
+    const inCard = calls.some(c =>
+      c.method === 'POST' &&
+      /\/cards\/[^/]+\/elements$/.test(c.path) &&
+      String(c.body?.elements ?? '').includes('短恢复轮输出'),
+    )
+    expect(inCard).toBe(true)
+    // 卡片已收尾(有终态 settings patch),session 不卡在 working。
+    expect(session.status).toBe('idle')
+  })
+
+  test('切换 provider 停旧进程时清掉 bgResumePending,新进程 boot init 不误开恢复卡', async () => {
+    const session = new Session('probe', 'chat_id') as any
+    const proc = new FakeAgentProc('claude', 'claude-session-1')
+    session.proc = proc
+    session.selectedProvider = 'codex' // 与 proc.provider 不一致 → 视为 idle mismatched
+    session.bgResumePending = true
+
+    await session.stopIdleMismatchedProcess()
+
+    expect(session.bgResumePending).toBe(false)
+    expect(session.proc).toBeNull()
+  })
+
+  test('非开卡/非恢复窗口的游离正文被丢弃,不进孤儿缓冲', () => {
+    const session = new Session('probe', 'chat_id') as any
+    // 无 currentTurn、无 openingTurn、无 bgResumeCardless:任何游离 delta 都该丢。
+    session.appendAssistant('进程 kill 窗口的残字')
+    session.finalizeCurrentAssistantSegment()
+
+    expect(session.orphanAssistantSegments).toEqual([])
+    expect(session.orphanAssistantCurrent).toBe('')
   })
 })

--- a/src/session.ts
+++ b/src/session.ts
@@ -176,6 +176,27 @@ export class Session {
   private lastMainTaskToolUseId: string | null = null
   /** onUserMessage 沉降旧卡后置位;主卡落地后据此重建后台卡(游标重回末尾)。 */
   private pendingRebuildBackgroundCard = false
+  /** turn 收尾后有后台任务结算 → SDK 会自发开一轮恢复轮(task_notification
+   *  合并结果),该轮 init 没有伴随用户消息。置位后,下一个无用户批次的 init
+   *  据此开 bg_task_resume 卡承接输出;任何 turn 开卡即消费(结算通知会被
+   *  并入那一轮),避免陈旧标记把无关的空 init 误判成恢复轮。 */
+  private bgResumePending = false
+  /** 无 currentTurn 时到达的 assistant 正文(恢复轮开卡前的窗口期 / 开卡
+   *  失败)。openTurnCard 落地时并入新卡;result/exit 时纯文本兜底推送。
+   *  决不静默丢弃(2026-07-04 etmmo 终报告事故:恢复轮 6.6KB 合并终报告
+   *  整轮无卡,appendAssistant 首行 return 全部丢光,飞书无痕)。
+   *  只在"合法无卡窗口"缓冲(openingTurn 正在开卡 / bgResumeCardless 恢复轮
+   *  开卡失败续窗);其余无卡场景(被打断的轮尾、kill 窗口残字)一律丢弃,
+   *  否则会被错误推送或并入下一张不相干的卡。 */
+  private orphanAssistantSegments: string[] = []
+  private orphanAssistantCurrent = ''
+  /** 恢复轮 openTurnCard 失败后置位:该轮此后再无卡,正文继续进孤儿缓冲直到
+   *  result 纯文本兜底。区别于 openingTurn(仅开卡 await 窗口)。 */
+  private bgResumeCardless = false
+  /** result 抢在 openTurnCard 的 sendCard/id_convert await 窗口内到达 →
+   *  置位;开卡 IIFE 落地后据此立即收尾,避免卡片永远悬挂、session 卡在
+   *  working(旧代码对 user turn 也有此隐患,这里一并收口)。 */
+  private sawResultWhileOpening = false
   pendingPermissions = new Map<string, { toolUseId: string; permissionSuggestions?: unknown }>()
   /** Open AskUserQuestion tool calls — keyed by tool_use_id. Codex and
    * Claude both route AskUserQuestion through the can_use_tool flow;
@@ -507,6 +528,11 @@ export class Session {
     log(`session "${this.sessionName}": stop idle ${proc.provider} process after switching to ${this.selectedProvider}`)
     this.proc = null
     this.initCount = 0
+    // 进程换掉:恢复轮标记 / 孤儿缓冲随旧进程作废,否则会泄漏到新进程的
+    // boot init,把一次干净启动误判成 bg_task_resume 轮开出幽灵卡。
+    this.bgResumePending = false
+    this.sawResultWhileOpening = false
+    this.discardOrphanAssistant()
     this.currentTurnUsageBaseline = null
     this.currentTurnUsageBaselineKnown = false
     this.usageTotalsSeedUnknown = false
@@ -522,6 +548,9 @@ export class Session {
     log(`session "${this.sessionName}": stop idle ${proc.provider} process: ${reason}`)
     this.proc = null
     this.initCount = 0
+    this.bgResumePending = false
+    this.sawResultWhileOpening = false
+    this.discardOrphanAssistant()
     this.currentTurnUsageBaseline = null
     this.currentTurnUsageBaselineKnown = false
     this.usageTotalsSeedUnknown = false
@@ -893,6 +922,10 @@ export class Session {
     this.releaseAllReactions()
     this.initCount = 0
     this.openingTurn = false
+    this.bgResumePending = false
+    this.sawResultWhileOpening = false
+    // 用户主动停止:孤儿缓冲随轮作废,不兜底推送。
+    this.discardOrphanAssistant()
     this.pendingAsks.clear()
     this.pendingHostAsks.clear()
     this.pendingPermissions.clear()
@@ -923,10 +956,18 @@ export class Session {
     const closeInternalStatusCard = async (finalStatus: string): Promise<void> => {
       if (statusCard) await this.closeStatusCard(statusCard, finalStatus)
     }
+    // 主动重启:孤儿缓冲随轮作废,不兜底推送。必须在 kill 之前丢弃 ——
+    // 否则 kill 触发的 exit 处理器会抢先把缓冲当作"进程崩溃残留"兜底推出去,
+    // 违背 restart 的作废语义。null this.proc 也放到 kill 之前,让 exit 走
+    // stale-proc 早退,不再重复兜底(与 stop() 同一模式)。
+    this.bgResumePending = false
+    this.sawResultWhileOpening = false
+    this.discardOrphanAssistant()
     if (this.proc) {
       report?.(`🛑 停止当前 ${this.backendLabel(this.proc.provider)}`)
-      await this.proc.kill()
+      const proc = this.proc
       this.proc = null
+      await proc.kill()
     }
     this.stopFooterStatus(this.currentTurn)
     this.currentTurn = null
@@ -938,6 +979,7 @@ export class Session {
     this.releaseAllReactions()
     this.initCount = 0
     this.openingTurn = false
+    // bgResumePending / 孤儿缓冲已在 kill 前作废(见上)。
     this.pendingAsks.clear()
     this.pendingHostAsks.clear()
     this.pendingPermissions.clear()
@@ -1673,7 +1715,14 @@ export class Session {
       // the openingTurn guard catches the eager-open vs init race.
       if (this.currentTurn || this.openingTurn) return
       const isUserBatch = this.pendingUserMessageCount > 0
-      if (!isUserBatch) return
+      // SDK 自发恢复轮:后台任务结算通知唤醒 SDK 合并结果,init 没有伴随
+      // 用户消息。必须照样开卡,否则这一轮的全部正文会被 appendAssistant
+      // 静默丢弃(2026-07-04 etmmo 终报告事故)。bgResumePending 只在
+      // bg_task_settled 落在无活跃 turn 时置位,保证 probe/模型切换等
+      // 无关的空 init 不受影响。
+      const isBgResume = !isUserBatch && this.bgResumePending
+      if (!isUserBatch && !isBgResume) return
+      this.bgResumePending = false
       const userOpenId = this.lastUserOpenId
       if (isUserBatch) {
         this.pendingUserMessageCount = 0
@@ -1684,19 +1733,43 @@ export class Session {
         this.pendingReactionIds = new Map()
       }
       this.openingTurn = true
+      this.sawResultWhileOpening = false // 本次开卡的竞态标记,落地时判定
       void (async () => {
         try {
-          await this.openTurnCard(userOpenId, 'user_message')
+          await this.openTurnCard(userOpenId, isUserBatch ? 'user_message' : 'bg_task_resume')
           if (!this.currentTurn) {
-            // SDK already started this turn (its `init` is what got us
-            // here) but we have no card to render into. Interrupt so
-            // assistant/tool events aren't silently dropped while the
-            // model burns tokens. Release the reactions this batch
-            // inherited (init handler moved them above) — otherwise
-            // they stay ⏳ forever on the user's chat messages.
-            log(`session "${this.sessionName}": init-path openTurnCard failed — sendInterrupt + release reactions`)
-            this.proc?.sendInterrupt()
-            this.releaseAllReactions()
+            if (isUserBatch) {
+              // SDK already started this turn (its `init` is what got us
+              // here) but we have no card to render into. Interrupt so
+              // assistant/tool events aren't silently dropped while the
+              // model burns tokens. Release the reactions this batch
+              // inherited (init handler moved them above) — otherwise
+              // they stay ⏳ forever on the user's chat messages.
+              log(`session "${this.sessionName}": init-path openTurnCard failed — sendInterrupt + release reactions`)
+              this.proc?.sendInterrupt()
+              this.releaseAllReactions()
+            } else {
+              // 恢复轮开卡失败不打断 —— 打断会把正在合并的后台结果整轮
+              // 作废。cardless 续窗:此后正文继续进孤儿缓冲。若 result 已在
+              // 开卡窗口内到达(不会再有第二次),这里立即兜底,否则由
+              // result 处理器 flush。
+              this.bgResumeCardless = true
+              if (this.sawResultWhileOpening) {
+                this.sawResultWhileOpening = false
+                log(`session "${this.sessionName}": bg-resume openTurnCard failed, result already arrived — flushing orphan now`)
+                this.flushOrphanAssistantToChat('bg-resume open failed, result already arrived')
+              } else {
+                log(`session "${this.sessionName}": bg-resume openTurnCard failed — orphan text flush will cover the output`)
+              }
+            }
+          } else if (this.sawResultWhileOpening) {
+            // 卡片开成了,但这一轮的 result 已在开卡 await 窗口内到达 ——
+            // result 处理器当时 currentTurn 还是 null,closeTurnCard 空转了。
+            // 这里补一次收尾,否则卡片 footer 永远计时、session 卡在 working。
+            this.sawResultWhileOpening = false
+            log(`session "${this.sessionName}": result raced card-open — closing freshly-opened turn card now`)
+            await this.closeTurnCard(undefined, { hasFreshResult: true })
+            this.status = 'idle'
           } else {
             this.status = 'working'
           }
@@ -1783,17 +1856,27 @@ export class Session {
     p.on('result', () => {
       this.persistResumableSessionId()
       this.accumulateResultStats()
+      // result 抢在 openTurnCard 的 await 窗口内到达:标记给开卡 IIFE,
+      // 它落地后据此立即收尾(否则卡片悬挂、session 卡在 working)。
+      if (this.openingTurn) this.sawResultWhileOpening = true
       // User just hit `stop` — this result is the SDK closing the in-flight
       // turn after sendInterrupt landed. The card already shows `🛑 打断`
-      // from the stop path, so skip the rest unconditionally.
+      // from the stop path, so skip the rest unconditionally. 被取消轮次的
+      // post-interrupt 尾巴随之作废,不兜底推送。
       if (this.userInterrupted) {
         this.userInterrupted = false
+        this.discardOrphanAssistant()
+        this.bgResumePending = false
         const subtype = this.proc?.lastResult.subtype ?? 'unknown'
         const isError = this.proc?.lastResult.is_error === true
         log(`session "${this.sessionName}": SDK result after user stop subtype=${subtype} isError=${isError} — ignored`)
         this.status = 'idle'
         return
       }
+      // 整轮无卡且不在开卡中(恢复轮开卡失败):孤儿正文纯文本兜底。开卡
+      // 窗口内(openingTurn)不 flush —— 让 openTurnCard 把缓冲并入卡片,
+      // 避免又推一遍。有卡的轮次已在开卡时并入,这里 flush 为 no-op。
+      if (!this.currentTurn && !this.openingTurn) this.flushOrphanAssistantToChat('result with no turn card')
       const hasMidTurn = this.pendingMidTurnMsgs.length > 0
       const isError = this.proc?.lastResult.is_error === true
       const subtype = this.proc?.lastResult.subtype ?? 'success'
@@ -1839,6 +1922,11 @@ export class Session {
       log(`session "${this.sessionName}": bg_task_settled task=${e.task_id} status=${e.status}`)
       this.applyBgStore(cards.applyBgTaskSettled(this.bgStore(), e))
       this.onBackgroundTaskChanged()
+      // turn 已收尾后才结算的任务:SDK 会自发开一轮恢复轮合并结果,
+      // 标记给下一个无用户批次的 init 开卡。
+      if (!this.currentTurn && !this.openingTurn && this.initCount >= 1) {
+        this.bgResumePending = true
+      }
     })
     p.on('exit', ({ code, signal, expected }: any) => {
       log(`session "${this.sessionName}": ${p.provider} exited code=${code} signal=${signal} expected=${expected}`)
@@ -1847,6 +1935,13 @@ export class Session {
         return
       }
       this.proc = null
+      // 进程死了,残留的孤儿正文再不兜底就永远丢了(非用户主动停止的崩溃
+      // 路径;stop/restart 已在 kill 前 null 掉 this.proc,走上面的 stale
+      // 早退不到这里)。
+      this.flushOrphanAssistantToChat('process exit')
+      this.bgResumePending = false
+      this.bgResumeCardless = false
+      this.sawResultWhileOpening = false
       this.stopFooterStatus(this.currentTurn)
       this.currentTurn = null
       this.clearMultiMsgBuffer('process exit')
@@ -1983,9 +2078,12 @@ export class Session {
 
   private async openTurnCard(
     userOpenId: string,
-    trigger: 'user_message',
+    trigger: TurnState['trigger'],
     opts: { initialFooter?: string; startThinking?: boolean; directStart?: boolean } = {},
   ): Promise<void> {
+    // 任何 turn 开卡都消费掉 pending 的恢复轮标记 —— 若用户消息抢在恢复轮
+    // init 前开了卡,SDK 会把结算通知并入该轮,标记留着只会误伤后续空 init。
+    this.bgResumePending = false
     // ── 后台游标卡迁移 ── 发新主卡前,先把旧后台卡沉降(终态墓碑/固定标识),
     // 主卡落地后(currentTurn 赋值处)重建后台卡重回末尾。迁移失败不阻塞主卡。
     if (this.backgroundCard && cards.hasActiveBgTask(this.backgroundTasks)) {
@@ -2025,10 +2123,14 @@ export class Session {
       // know to resend instead of waiting for a reply that won't come.
       // Use raw fetch (not sendText) because if the SDK is the broken
       // thing we'd be doomed to silence otherwise.
-      await feishu.sendTextRaw(
-        this.chatId,
-        '❌ 创建对话卡片失败 (Feishu SDK 重试 3 次后仍连不上)。你这条消息没能送到 Codex,请稍后重发。',
-      )
+      // bg-resume 轮没有"用户这条消息",提示重发只会误导;其输出会走
+      // 孤儿缓冲纯文本兜底,这里不必告警。
+      if (trigger === 'user_message') {
+        await feishu.sendTextRaw(
+          this.chatId,
+          '❌ 创建对话卡片失败 (Feishu SDK 重试 3 次后仍连不上)。你这条消息没能送到 Codex,请稍后重发。',
+        )
+      }
       // currentTurn left null as the failure signal. Caller decides
       // whether to sendInterrupt: onUserMessage's eager-open path
       // hasn't fed SDK yet so doesn't need to; the init handler has
@@ -2040,8 +2142,9 @@ export class Session {
     catch (e) { log(`session "${this.sessionName}": id_convert failed: ${e}`); return }
     // Tell cardkit how many elements the initial body already has so
     // its element-count tracker is correct from the first addElement
-    // onwards (userInputPanel + footer).
+    // onwards (bg-resume banner + userInputPanel + footer).
     const initialElementCount =
+      (trigger === 'bg_task_resume' ? 1 : 0) +
       (userInputs.length > 0 ? 1 : 0) +
       1
     cardkit.recordCardCreated(cardId, initialElementCount, (code) => this.onCardWriteFailure(code))
@@ -2082,6 +2185,13 @@ export class Session {
     }
     this.currentTurn = turnState
     if (opts.startThinking !== false) this.startThinkingFooter(turnState)
+    // 开卡 await 窗口期(sendCard/id_convert)先到的 assistant 正文攒在
+    // 孤儿缓冲里,现在有卡了,作为首段并入 —— 后续 delta 接着正常追加。
+    const orphan = this.takeOrphanAssistantText()
+    if (orphan) {
+      this.appendAssistant(orphan)
+      this.finalizeCurrentAssistantSegment()
+    }
     // 主卡落地 → 若刚迁移过旧后台卡且仍有活跃任务,重建后台卡重回末尾。
     if (this.pendingRebuildBackgroundCard) {
       this.pendingRebuildBackgroundCard = false
@@ -2460,7 +2570,14 @@ export class Session {
   }
 
   private appendAssistant(delta: string): void {
-    if (!this.currentTurn) return
+    if (!this.currentTurn) {
+      // 只在合法无卡窗口缓冲:正在开卡(openingTurn),或恢复轮开卡失败后
+      // 的续窗(bgResumeCardless)。其余无卡场景(被打断的轮尾、进程 kill
+      // 窗口的残字、轮间游离 delta)一律丢弃 —— 缓冲下来只会被错误推送或
+      // 并入下一张不相干的卡(旧代码此处直接 return 丢弃,行为一致)。
+      if (this.openingTurn || this.bgResumeCardless) this.orphanAssistantCurrent += delta
+      return
+    }
     const turn = this.currentTurn
     // 第一条 assistant text_delta 到达 → footer 切到 Writing 计时。
     // 正文自身只进入内存缓冲,等 agentMessage completed 后一次性插入卡片。
@@ -2496,6 +2613,33 @@ export class Session {
     cardkit.patchSummaryThrottled(turn.cardId, tail)
   }
 
+  /** 取走并清空孤儿 assistant 缓冲(定稿段 + 未定稿尾段,空行分隔)。 */
+  private takeOrphanAssistantText(): string {
+    const parts = [...this.orphanAssistantSegments]
+    if (this.orphanAssistantCurrent.trim()) parts.push(this.orphanAssistantCurrent)
+    this.orphanAssistantSegments = []
+    this.orphanAssistantCurrent = ''
+    return parts.join('\n\n').trim()
+  }
+
+  /** 丢弃孤儿缓冲并复位 cardless 续窗标记 —— 用户主动作废(打断/停止/重启)
+   *  或进程被替换时调用,内容随轮作废不兜底。 */
+  private discardOrphanAssistant(): void {
+    this.orphanAssistantSegments = []
+    this.orphanAssistantCurrent = ''
+    this.bgResumeCardless = false
+  }
+
+  /** 无卡兜底:孤儿正文以纯文本消息推进聊天 —— 宁可丢排版,不可丢内容。 */
+  private flushOrphanAssistantToChat(reason: string): void {
+    const text = this.takeOrphanAssistantText()
+    if (!text) return
+    const display = this.cleanAssistantTextForDisplay(text).trim()
+    if (!display) return
+    log(`session "${this.sessionName}": flushing ${display.length} chars of orphan assistant text (${reason})`)
+    void feishu.sendText(this.chatId, `📄 后台轮输出(未能建卡,纯文本兜底):\n\n${display}`)
+  }
+
   private completedAssistantElement(segId: string, text: string): object {
     return {
       tag: 'markdown',
@@ -2516,7 +2660,12 @@ export class Session {
    * 一次性插入静态 markdown,然后清空段游标。 */
   finalizeCurrentAssistantSegment(): void {
     const turn = this.currentTurn
-    if (!turn) return
+    if (!turn) {
+      // 无卡窗口的段边界:当前孤儿段定稿进列表,flush 时段间以空行分隔。
+      if (this.orphanAssistantCurrent.trim()) this.orphanAssistantSegments.push(this.orphanAssistantCurrent)
+      this.orphanAssistantCurrent = ''
+      return
+    }
     // 正在切卡:别动当前段 —— rotate 会在 swap 时读 currentAssistantText carry
     // 到新卡续写。这里若定稿/reset,过渡窗口里的当前段文字会被清空、carry 落空
     // (跟 appendAssistant onFailure 在 rotating 期间不 reset 同一个道理)。代价是


### PR DESCRIPTION
## 问题

SDK 在后台子任务结算后会自发开一轮“恢复轮”(init 无用户消息)来合并结果。旧 init handler 仅在 `pendingUserMessageCount > 0` 时开卡,恢复轮不开卡;`appendAssistant` 首行 `if (!currentTurn) return` 就把整轮正文(含合并终报告)静默丢弃 —— 飞书侧无痕。实测一次 6.6KB 的合并终报告因此完全消失。

## 修复

- `bg_task_settled` 在无活跃 turn 时置 `bgResumePending`;下一个无用户批次的 init 据此开 `bg_task_resume` 卡承接输出。
- 孤儿缓冲仅在合法无卡窗口(`openingTurn` / `bgResumeCardless`)缓冲正文:`openTurnCard` 落地并入新卡,整轮无卡时纯文本兜底;被打断 / kill / 重启的游离正文一律丢弃,不误推、不污染下一张卡。
- `result` 抢在开卡 await 窗口到达时补收尾,避免卡片悬挂、session 卡在 working。
- `stop / restart / exit / stopIdle*` 一致清理 `bgResumePending` 与孤儿缓冲,修复换 provider 时标记泄漏出幽灵恢复卡。

## 测试

新增 8 个场景测试覆盖恢复轮开卡、竞态、打断丢弃、标记泄漏。全量 `bun test`:**260 pass / 0 fail**。
