### PR TITLE
feat(model): 官方 Fable5/Opus4.8 档位 + GLM 第三方 per-model token 路由

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,7 @@
+[test]
+# 先于任何测试文件注册 ./feishu 的共享 mock(feishu-test-mock.ts)。
+# bun 的 mock.module 是异步注册,静态 import 间无 await 点:一旦某个被测模块
+# (如 notify.ts → ./feishu)在 mock 生效前被加载,真实 feishu 会被缓存,
+# 后续 session.test.ts 等拿到的就是真实模块(读到宿主真实 config)。
+# preload 保证 mock 在首个测试文件加载前注册,加载顺序不再影响结果。
+preload = ["./src/feishu-test-mock.ts"]

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -30,6 +30,7 @@ const {
   claudeModelEnv,
   claudeModelIsApiRoute,
   claudeModelConfigured,
+  claudeModelEffort,
 } = await import('./claude-models')
 const { config } = await import('./config')
 
@@ -135,6 +136,31 @@ describe('Claude model profiles', () => {
       })
       // 官方模型仍然干净,GLM 的 token 不外泄到登录态档位。
       expect(claudeModelEnv('claude:opus')).toEqual({})
+    } finally {
+      ;(config.claude as any).models = prev
+    }
+  })
+
+  test('claudeModelEffort: GLM 档位读 config 里的 effort;缺省/官方档位返回 undefined', () => {
+    const prev = config.claude.models
+    ;(config.claude as any).models = {
+      glm: { model: 'glm-5.2', base_url: 'https://open.bigmodel.cn/api/anthropic', auth_token: 't', effort: 'xhigh' },
+    }
+    try {
+      expect(claudeModelEffort('claude:glm')).toBe('xhigh')
+      expect(claudeModelEffort('claude:opus')).toBeUndefined() // 官方档位不从 config 取 effort
+    } finally {
+      ;(config.claude as any).models = prev
+    }
+  })
+
+  test('claudeModelEffort: 非法 effort 值被忽略(返回 undefined,回落固定值)', () => {
+    const prev = config.claude.models
+    ;(config.claude as any).models = {
+      glm: { model: 'glm-5.2', base_url: 'https://x', auth_token: 't', effort: 'turbo' },
+    }
+    try {
+      expect(claudeModelEffort('claude:glm')).toBeUndefined()
     } finally {
       ;(config.claude as any).models = prev
     }

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -156,6 +156,11 @@ describe('Claude model profiles', () => {
       expect(claudeModelEnv('claude:glm')).toEqual({
         ANTHROPIC_BASE_URL: 'https://open.bigmodel.cn/api/anthropic',
         ANTHROPIC_AUTH_TOKEN: 'glm-secret-token',
+        // 内置默认别名映射(智谱最强组合):config 未配 env_* 时自动注入
+        ANTHROPIC_DEFAULT_FABLE_MODEL: 'glm-5.2[1m]',
+        ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5.2[1m]',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5-turbo',
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: 'glm-5-turbo',
       })
       // 官方模型仍然干净,GLM 的 token 不外泄到登录态档位。
       expect(claudeModelEnv('claude:opus')).toEqual({})

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -27,6 +27,9 @@ const {
 } = await import('./claude-agent-process')
 const {
   resolveClaudeSdkModel,
+  claudeModelEnv,
+  claudeModelIsApiRoute,
+  claudeModelConfigured,
 } = await import('./claude-models')
 const { config } = await import('./config')
 
@@ -93,6 +96,78 @@ describe('Claude model profiles', () => {
   test('maps GLM and DeepSeek profiles to SDK model and env tiers', () => {
     expect(resolveClaudeSdkModel('claude:default')).toBe('claude-fable-5')
     expect(resolveClaudeSdkModel('claude:glm')).toBe('claude-fable-5')
+  })
+
+  test('maps first-party Claude Code profiles to their SDK model ids', () => {
+    expect(resolveClaudeSdkModel('claude:opus')).toBe('claude-opus-4-8')
+    expect(resolveClaudeSdkModel('claude:fable')).toBe('claude-fable-5')
+  })
+
+  test('official (login) Claude models inject no ANTHROPIC_* env and are not API routes', () => {
+    expect(claudeModelEnv('claude:fable')).toEqual({})
+    expect(claudeModelEnv('claude:opus')).toEqual({})
+    expect(claudeModelIsApiRoute('claude:fable')).toBe(false)
+    expect(claudeModelIsApiRoute('claude:opus')).toBe(false)
+  })
+
+  test('GLM is an API route that stays unconfigured until a token is set in lodestar config', () => {
+    // 默认(无 config)→ GLM 是 api 路由但未配置,env 为空。
+    expect(claudeModelIsApiRoute('claude:glm')).toBe(true)
+    expect(claudeModelConfigured('claude:glm')).toBe(false)
+    expect(claudeModelEnv('claude:glm')).toEqual({})
+  })
+
+  test('a configured GLM profile injects base_url + auth_token as ANTHROPIC_* env', () => {
+    const prev = config.claude.models
+    ;(config.claude as any).models = {
+      glm: {
+        model: 'glm-4.6',
+        base_url: 'https://open.bigmodel.cn/api/anthropic',
+        auth_token: 'glm-secret-token',
+      },
+    }
+    try {
+      expect(claudeModelConfigured('claude:glm')).toBe(true)
+      expect(resolveClaudeSdkModel('claude:glm')).toBe('glm-4.6')
+      expect(claudeModelEnv('claude:glm')).toEqual({
+        ANTHROPIC_BASE_URL: 'https://open.bigmodel.cn/api/anthropic',
+        ANTHROPIC_AUTH_TOKEN: 'glm-secret-token',
+      })
+      // 官方模型仍然干净,GLM 的 token 不外泄到登录态档位。
+      expect(claudeModelEnv('claude:opus')).toEqual({})
+    } finally {
+      ;(config.claude as any).models = prev
+    }
+  })
+
+  test('buildSpawnEnv: 登录档位抹掉环境里的 ANTHROPIC_*;GLM 只注入自己的 key,不夹带残留官方 key', () => {
+    const prevKey = process.env.ANTHROPIC_API_KEY
+    const prevModels = config.claude.models
+    // 残留一个官方 API key 在环境里(模拟用户 shell / 全局注入)。
+    process.env.ANTHROPIC_API_KEY = 'stray-official-key'
+    ;(config.claude as any).models = {
+      glm: { model: 'glm-4.6', base_url: 'https://glm.example/anthropic', auth_token: 'glm-tok' },
+    }
+    try {
+      // 官方登录档位:三个路由 key 全被抹掉,保证纯登录态。
+      const login = new ClaudeAgentProcess({ workDir: '/tmp', effort: 'max', model: 'claude:opus' })
+      const loginEnv = (login as any).buildSpawnEnv()
+      expect(loginEnv.ANTHROPIC_API_KEY).toBeUndefined()
+      expect(loginEnv.ANTHROPIC_BASE_URL).toBeUndefined()
+      expect(loginEnv.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+
+      // GLM 第三方路由:注入自己的 base_url + auth_token,但残留的官方 key
+      // 被先抹掉,不会夹带打到第三方端点。
+      const glm = new ClaudeAgentProcess({ workDir: '/tmp', effort: 'max', model: 'claude:glm' })
+      const glmEnv = (glm as any).buildSpawnEnv()
+      expect(glmEnv.ANTHROPIC_BASE_URL).toBe('https://glm.example/anthropic')
+      expect(glmEnv.ANTHROPIC_AUTH_TOKEN).toBe('glm-tok')
+      expect(glmEnv.ANTHROPIC_API_KEY).toBeUndefined()
+    } finally {
+      if (prevKey === undefined) delete process.env.ANTHROPIC_API_KEY
+      else process.env.ANTHROPIC_API_KEY = prevKey
+      ;(config.claude as any).models = prevModels
+    }
   })
 })
 

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -91,8 +91,8 @@ describe('Claude model profiles', () => {
   })
 
   test('maps GLM and DeepSeek profiles to SDK model and env tiers', () => {
-    expect(resolveClaudeSdkModel('claude:default')).toBe('opus')
-    expect(resolveClaudeSdkModel('claude:glm')).toBe('opus')
+    expect(resolveClaudeSdkModel('claude:default')).toBe('claude-fable-5')
+    expect(resolveClaudeSdkModel('claude:glm')).toBe('claude-fable-5')
   })
 })
 

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -218,6 +218,43 @@ describe('Claude model profiles', () => {
       ;(config.claude as any).models = prevModels
     }
   })
+
+  test('buildSpawnEnv: GLM 档位注入 per-档位 env 别名映射(ANTHROPIC_DEFAULT_*);官方档位不注入', () => {
+    const prevModels = config.claude.models
+    // 清掉宿主 process.env 里残留的全局别名映射(模拟 Task5 删 [claude.env] 污染后),
+    // 否则官方档位会继承宿主的 DEFAULT_OPUS=claude-fable-5,干扰"零注入"断言。
+    const prevDefaultOpus = process.env.ANTHROPIC_DEFAULT_OPUS_MODEL
+    delete process.env.ANTHROPIC_DEFAULT_OPUS_MODEL
+    ;(config.claude as any).models = {
+      glm: {
+        model: 'glm-5.2[1m]',
+        base_url: 'https://open.bigmodel.cn/api/anthropic',
+        auth_token: 'glm-tok',
+        env: {
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5.2[1m]',
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5-turbo',
+        },
+      },
+    }
+    try {
+      // GLM 档位:别名映射随 base_url/token 一起注入子进程。
+      const glm = new ClaudeAgentProcess({ workDir: '/tmp', effort: 'max', model: 'claude:glm' })
+      const glmEnv = (glm as any).buildSpawnEnv()
+      expect(glmEnv.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic')
+      expect(glmEnv.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.2[1m]')
+      expect(glmEnv.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo')
+
+      // 官方登录档位:不注入任何 per-档位 env,opus/sonnet 别名走 CC 默认解析。
+      const opus = new ClaudeAgentProcess({ workDir: '/tmp', effort: 'max', model: 'claude:opus' })
+      const opusEnv = (opus as any).buildSpawnEnv()
+      expect(opusEnv.ANTHROPIC_DEFAULT_OPUS_MODEL).toBeUndefined()
+      expect(opusEnv.ANTHROPIC_BASE_URL).toBeUndefined()
+    } finally {
+      ;(config.claude as any).models = prevModels
+      if (prevDefaultOpus === undefined) delete process.env.ANTHROPIC_DEFAULT_OPUS_MODEL
+      else process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = prevDefaultOpus
+    }
+  })
 })
 
 describe('Claude configured executable ([claude] bin)', () => {

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -118,6 +118,29 @@ describe('Claude model profiles', () => {
     expect(claudeModelEnv('claude:glm')).toEqual({})
   })
 
+  test('API route profile without an explicit model stays unconfigured', () => {
+    // 只配了接入信息、忘了 model:sdkModel 会回落官方 claude-fable-5,
+    // 拿官方 model id 打第三方端点必然失败/误路由 —— 必须挡在 configured 门槛。
+    const prev = config.claude.models
+    ;(config.claude as any).models = {
+      glm: {
+        base_url: 'https://open.bigmodel.cn/api/anthropic',
+        auth_token: 'glm-secret-token',
+      },
+      // 非内建档位同样适用:任意第三方 relay 忘配 model 也一样拦。
+      relay: {
+        base_url: 'https://relay.example/api',
+        auth_token: 'relay-token',
+      },
+    }
+    try {
+      expect(claudeModelConfigured('claude:glm')).toBe(false)
+      expect(claudeModelConfigured('claude:relay')).toBe(false)
+    } finally {
+      ;(config.claude as any).models = prev
+    }
+  })
+
   test('a configured GLM profile injects base_url + auth_token as ANTHROPIC_* env', () => {
     const prev = config.claude.models
     ;(config.claude as any).models = {

--- a/src/claude-agent-process.ts
+++ b/src/claude-agent-process.ts
@@ -25,6 +25,8 @@ import {
 } from './agent-process'
 import {
   claudeModelKey,
+  claudeModelEnv,
+  claudeModelIsApiRoute,
   resolveClaudeSdkModel,
 } from './claude-models'
 import type {
@@ -670,6 +672,35 @@ export class ClaudeAgentProcess extends EventEmitter {
     this.lastModel = opts.model ? claudeModelKey(opts.model) : null
   }
 
+  /** spawn 用的 env。先建一个"无任何 ANTHROPIC_* 路由痕迹"的干净基线,再
+   * 按档位类型决定是否注入,两条路径对称,精确对应用户诉求:
+   *   - 官方登录档位(Fable 5/Opus,route:'login'):抹掉后不再注入 →
+   *     Claude Code 只用用户的登录态,绝不被残留 API key 悄悄改路由。
+   *   - 第三方 API 路由(GLM,route:'api'):抹掉后只注入该档位 config 声明
+   *     的 ANTHROPIC_* env(base_url + auth_token)→ 不会夹带残留的官方
+   *     ANTHROPIC_API_KEY 打到第三方端点(反之亦然)。
+   * 关键:scrub 放在 `...config.claude.env` 叠加之后 —— 所以即使误把 token
+   * 放进全局 [claude.env] 也会被抹掉;GLM token 必须放 [claude.models.glm]。
+   * 注意:此 scrub 只作用于 spawn 进程的 env;若 ~/.claude/settings.json 的
+   * env 块里配了 ANTHROPIC_BASE_URL/AUTH_TOKEN,Claude Code 仍会加载它 ——
+   * 故第三方路由请一律走 [claude.models.*],不要写进 settings.json。 */
+  private buildSpawnEnv(): Record<string, string> {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      PATH: buildClaudeSpawnPath(),
+      ...config.claude.env,
+    }
+    // 干净基线:无条件抹掉三个路由 key。
+    delete env.ANTHROPIC_BASE_URL
+    delete env.ANTHROPIC_AUTH_TOKEN
+    delete env.ANTHROPIC_API_KEY
+    // 第三方路由才注入该档位声明的接入 env;登录档位保持干净基线。
+    if (claudeModelIsApiRoute(this.opts.model)) {
+      Object.assign(env, claudeModelEnv(this.opts.model))
+    }
+    return env
+  }
+
   sendInitialize(): void {
     if (this.started) return
     this.started = true
@@ -689,7 +720,9 @@ export class ClaudeAgentProcess extends EventEmitter {
       // resolveClaudeExecutableConfig 在 [claude].bin 配错路径时同步抛出;
       // 必须在 try 内调用,确保错误走 error/exit 事件而非穿透到调用方。
       const executable = resolveClaudeExecutableConfig()
-      log(`claude-agent-process: spawn SDK query model=${model ?? 'default'} effort=${this.opts.effort} cwd=${this.opts.workDir} executable=${executable.description}`)
+      const spawnEnv = this.buildSpawnEnv()
+      const routeLabel = claudeModelIsApiRoute(this.opts.model) ? 'api' : 'login'
+      log(`claude-agent-process: spawn SDK query model=${model ?? 'default'} effort=${this.opts.effort} route=${routeLabel} cwd=${this.opts.workDir} executable=${executable.description}`)
       this.query = query({
         prompt: this.input,
         options: {
@@ -707,11 +740,7 @@ export class ClaudeAgentProcess extends EventEmitter {
             : {}),
           permissionMode: CLAUDE_PERMISSION_MODE,
           allowDangerouslySkipPermissions: CLAUDE_ALLOW_DANGEROUSLY_SKIP_PERMISSIONS,
-          env: {
-            ...(process.env as Record<string, string>),
-            PATH: buildClaudeSpawnPath(),
-            ...config.claude.env,
-          },
+          env: spawnEnv,
           settingSources,
           tools: toolsOption,
           ...(strictMcpConfig ? { strictMcpConfig: true } : {}),

--- a/src/claude-models.test.ts
+++ b/src/claude-models.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('./config', () => ({
+  config: {
+    claude: {
+      env: {},
+      models: {
+        glm: {
+          model: 'glm-5.2[1m]',
+          base_url: 'https://open.bigmodel.cn/api/anthropic',
+          auth_token: 'glm-tok',
+          effort: 'xhigh',
+          env: {
+            ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5.2[1m]',
+            ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5-turbo',
+            ANTHROPIC_DEFAULT_FABLE_MODEL: 'glm-5.2[1m]',
+            ANTHROPIC_DEFAULT_HAIKU_MODEL: 'glm-5-turbo',
+          },
+        },
+      },
+    },
+    codex: { env: {}, models: {} },
+  },
+}))
+
+const { claudeModelEnv, claudeModelIsApiRoute } = await import('./claude-models')
+
+describe('claudeModelEnv per-档位 env 注入', () => {
+  test('GLM 档位注入别名映射 + base_url/token', () => {
+    const env = claudeModelEnv('claude:glm')
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('glm-tok')
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.2[1m]')
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo')
+    expect(env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe('glm-5.2[1m]')
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5-turbo')
+  })
+
+  test('官方登录档位不注入任何 env(零污染)', () => {
+    expect(claudeModelEnv('claude:opus')).toEqual({})
+    expect(claudeModelEnv('claude:fable')).toEqual({})
+    expect(claudeModelIsApiRoute('claude:opus')).toBe(false)
+    expect(claudeModelIsApiRoute('claude:glm')).toBe(true)
+  })
+})

--- a/src/claude-models.test.ts
+++ b/src/claude-models.test.ts
@@ -1,32 +1,38 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { config } from './config'
+import { claudeModelEnv, claudeModelIsApiRoute } from './claude-models'
 
-mock.module('./config', () => ({
-  config: {
-    claude: {
-      env: {},
-      models: {
-        glm: {
-          model: 'glm-5.2[1m]',
-          base_url: 'https://open.bigmodel.cn/api/anthropic',
-          auth_token: 'glm-tok',
-          effort: 'xhigh',
-          env: {
-            ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5.2[1m]',
-            ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5-turbo',
-            ANTHROPIC_DEFAULT_FABLE_MODEL: 'glm-5.2[1m]',
-            ANTHROPIC_DEFAULT_HAIKU_MODEL: 'glm-5-turbo',
-          },
-        },
-      },
-    },
-    codex: { env: {}, models: {} },
+// 固定的 GLM 测试档位(不依赖宿主 config.toml,保证测试确定性)。
+// 注意:不用 mock.module('./config')。bun 的模块 mock 无法被 mock.restore() 撤销,
+// 在显式多文件同批运行(如 `bun test a.test.ts b.test.ts`)时会泄漏到同作用域其他
+// 文件 —— config.test.ts 真实 import './config' 的 parseClaudeModelProfile 会因此
+// 拿到本文件 mock 后的残缺对象而抛 SyntaxError。这里与 claude-agent-process.test.ts
+// 保持一致:直接改真实 config 单例的 glm 档位,afterEach 原样恢复。
+const GLM_FULL = {
+  model: 'glm-5.2[1m]',
+  base_url: 'https://open.bigmodel.cn/api/anthropic',
+  auth_token: 'glm-tok',
+  effort: 'xhigh',
+  env: {
+    ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5.2[1m]',
+    ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5-turbo',
+    ANTHROPIC_DEFAULT_FABLE_MODEL: 'glm-5.2[1m]',
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: 'glm-5-turbo',
   },
-}))
-
-const { claudeModelEnv, claudeModelIsApiRoute } = await import('./claude-models')
-const { config } = await import('./config')
+}
 
 describe('claudeModelEnv per-档位 env 注入', () => {
+  let prevGlm: unknown
+
+  beforeEach(() => {
+    prevGlm = config.claude.models.glm
+    ;(config.claude as any).models.glm = { ...GLM_FULL, env: { ...GLM_FULL.env } }
+  })
+
+  afterEach(() => {
+    ;(config.claude as any).models.glm = prevGlm
+  })
+
   test('GLM 档位注入别名映射 + base_url/token', () => {
     const env = claudeModelEnv('claude:glm')
     expect(env.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic')
@@ -45,7 +51,6 @@ describe('claudeModelEnv per-档位 env 注入', () => {
   })
 
   test('glm 档位 config 未配 env_* → 用内置默认最强组合', () => {
-    const prevGlm = config.claude.models.glm
     ;(config.claude as any).models.glm = {
       model: 'glm-5.2[1m]',
       base_url: 'https://open.bigmodel.cn/api/anthropic',
@@ -53,33 +58,24 @@ describe('claudeModelEnv per-档位 env 注入', () => {
       effort: 'xhigh',
       // 无 env_* —— 应回落代码内置默认
     }
-    try {
-      const env = claudeModelEnv('claude:glm')
-      expect(env.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic')
-      expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.2[1m]')
-      expect(env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe('glm-5.2[1m]')
-      expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo')
-      expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5-turbo')
-    } finally {
-      ;(config.claude as any).models.glm = prevGlm
-    }
+    const env = claudeModelEnv('claude:glm')
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic')
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.2[1m]')
+    expect(env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe('glm-5.2[1m]')
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo')
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5-turbo')
   })
 
   test('glm 档位 config 显式配某 env_* → 仅覆盖该 key,其余用默认', () => {
-    const prevGlm = config.claude.models.glm
     ;(config.claude as any).models.glm = {
       model: 'glm-5.2[1m]',
       base_url: 'https://open.bigmodel.cn/api/anthropic',
       auth_token: 'glm-tok',
       env: { ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-4.6' }, // 只覆盖 opus
     }
-    try {
-      const env = claudeModelEnv('claude:glm')
-      expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-4.6') // config 覆盖
-      expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo') // 默认
-      expect(env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe('glm-5.2[1m]') // 默认
-    } finally {
-      ;(config.claude as any).models.glm = prevGlm
-    }
+    const env = claudeModelEnv('claude:glm')
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-4.6') // config 覆盖
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo') // 默认
+    expect(env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe('glm-5.2[1m]') // 默认
   })
 })

--- a/src/claude-models.test.ts
+++ b/src/claude-models.test.ts
@@ -24,6 +24,7 @@ mock.module('./config', () => ({
 }))
 
 const { claudeModelEnv, claudeModelIsApiRoute } = await import('./claude-models')
+const { config } = await import('./config')
 
 describe('claudeModelEnv per-档位 env 注入', () => {
   test('GLM 档位注入别名映射 + base_url/token', () => {
@@ -41,5 +42,44 @@ describe('claudeModelEnv per-档位 env 注入', () => {
     expect(claudeModelEnv('claude:fable')).toEqual({})
     expect(claudeModelIsApiRoute('claude:opus')).toBe(false)
     expect(claudeModelIsApiRoute('claude:glm')).toBe(true)
+  })
+
+  test('glm 档位 config 未配 env_* → 用内置默认最强组合', () => {
+    const prevGlm = config.claude.models.glm
+    ;(config.claude as any).models.glm = {
+      model: 'glm-5.2[1m]',
+      base_url: 'https://open.bigmodel.cn/api/anthropic',
+      auth_token: 'glm-tok',
+      effort: 'xhigh',
+      // 无 env_* —— 应回落代码内置默认
+    }
+    try {
+      const env = claudeModelEnv('claude:glm')
+      expect(env.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic')
+      expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.2[1m]')
+      expect(env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe('glm-5.2[1m]')
+      expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo')
+      expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5-turbo')
+    } finally {
+      ;(config.claude as any).models.glm = prevGlm
+    }
+  })
+
+  test('glm 档位 config 显式配某 env_* → 仅覆盖该 key,其余用默认', () => {
+    const prevGlm = config.claude.models.glm
+    ;(config.claude as any).models.glm = {
+      model: 'glm-5.2[1m]',
+      base_url: 'https://open.bigmodel.cn/api/anthropic',
+      auth_token: 'glm-tok',
+      env: { ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-4.6' }, // 只覆盖 opus
+    }
+    try {
+      const env = claudeModelEnv('claude:glm')
+      expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-4.6') // config 覆盖
+      expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo') // 默认
+      expect(env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe('glm-5.2[1m]') // 默认
+    } finally {
+      ;(config.claude as any).models.glm = prevGlm
+    }
   })
 })

--- a/src/claude-models.ts
+++ b/src/claude-models.ts
@@ -1,4 +1,5 @@
 import { config, type ClaudeModelConfig } from './config'
+import { isClaudeReasoningEffort, type ClaudeReasoningEffort } from './agent-process'
 
 export interface ClaudeModelProfile {
   key: string
@@ -143,4 +144,14 @@ export function claudeModelConfigured(model: string | null | undefined): boolean
   const profile = claudeModelProfile(model)
   // 未知/默认档位当作登录态就绪。
   return profile ? profile.configured : true
+}
+
+/** 该档位在 config 里声明的思考强度(仅第三方 API 路由有意义,官方登录档位
+ * 不配)。非法/未配返回 undefined,由调用方回落到 FIXED_MODEL_CHOICES 的锁死
+ * 值。让 GLM 能复刻各自最优 effort(如 GLM-5.2 直连智谱走 xhigh)。 */
+export function claudeModelEffort(model: string | null | undefined): ClaudeReasoningEffort | undefined {
+  const profile = claudeModelProfile(model)
+  if (!profile || profile.route !== 'api') return undefined
+  const raw = mergedConfig(profile.name).effort?.trim()
+  return raw && isClaudeReasoningEffort(raw) ? raw : undefined
 }

--- a/src/claude-models.ts
+++ b/src/claude-models.ts
@@ -12,6 +12,11 @@ type DefaultClaudeModelConfig = Required<
   Pick<ClaudeModelConfig, 'display_name' | 'description'>
 >
 
+// 未在 config.toml [claude.models.*] 指定 model 时的默认档位。
+// Fable 5 是 Anthropic 当前最强模型(1M ctx / 128K out),官方 API 路由可用;
+// GLM 等第三方路由不认这个 id,需在 profile 里显式配 model 覆盖。
+export const DEFAULT_CLAUDE_SDK_MODEL = 'claude-fable-5'
+
 const DEFAULT_CLAUDE_MODELS: Record<string, DefaultClaudeModelConfig> = {
   glm: {
     display_name: 'Claude Code · GLM',
@@ -37,7 +42,7 @@ function toProfile(name: string): ClaudeModelProfile | null {
     name,
     displayName: raw.display_name?.trim() || `Claude Code · ${name}`,
     description: raw.description?.trim() || `使用 ${name} 路由运行 Claude Code 后端。`,
-    sdkModel: raw.model?.trim() || 'opus',
+    sdkModel: raw.model?.trim() || DEFAULT_CLAUDE_SDK_MODEL,
   }
 }
 
@@ -63,9 +68,9 @@ export function claudeModelKey(model: string): string {
 }
 
 export function resolveClaudeSdkModel(model: string | null | undefined): string | undefined {
-  if (!model) return 'opus'
+  if (!model) return DEFAULT_CLAUDE_SDK_MODEL
   const profile = claudeModelProfile(model)
   if (profile) return profile.sdkModel
   const stripped = model.startsWith('claude:') ? model.slice('claude:'.length) : model
-  return stripped === 'default' ? 'opus' : stripped
+  return stripped === 'default' ? DEFAULT_CLAUDE_SDK_MODEL : stripped
 }

--- a/src/claude-models.ts
+++ b/src/claude-models.ts
@@ -13,7 +13,7 @@ export interface ClaudeModelProfile {
   /** spawn 时注入的 ANTHROPIC_* env 覆盖。login 档位恒为空;api 档位配好
    * 后为 { ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN[, ANTHROPIC_API_KEY] }。 */
   env: Record<string, string>
-  /** login 恒 true;api 需 base_url + auth_token 都配好才 true。 */
+  /** login 恒 true;api 需 base_url + auth_token + model 都配好才 true。 */
   configured: boolean
 }
 
@@ -81,10 +81,13 @@ function toProfile(name: string): ClaudeModelProfile | null {
       ? raw.route
       : Object.keys(env).length > 0 ? 'api' : 'login'
   // login 恒就绪;api 需 base_url + auth_token 都在(api_key 单独也算,GLM 用
-  // auth_token,少数三方用 api_key)。
+  // auth_token,少数三方用 api_key),且必须显式配 model —— 缺 model 时 sdkModel
+  // 回落官方 DEFAULT_CLAUDE_SDK_MODEL,拿官方 model id 打第三方端点必然误路由。
   const configured =
     route === 'login' ||
-    (!!env.ANTHROPIC_BASE_URL && (!!env.ANTHROPIC_AUTH_TOKEN || !!env.ANTHROPIC_API_KEY))
+    (!!env.ANTHROPIC_BASE_URL &&
+      (!!env.ANTHROPIC_AUTH_TOKEN || !!env.ANTHROPIC_API_KEY) &&
+      !!raw.model?.trim())
   return {
     key,
     name,

--- a/src/claude-models.ts
+++ b/src/claude-models.ts
@@ -68,6 +68,12 @@ function envFromConfig(raw: ClaudeModelConfig): Record<string, string> {
   if (baseUrl) env.ANTHROPIC_BASE_URL = baseUrl
   if (authToken) env.ANTHROPIC_AUTH_TOKEN = authToken
   if (apiKey) env.ANTHROPIC_API_KEY = apiKey
+  // per-档位 env 注入(GLM 用它映射 opus/sonnet/fable 别名到 GLM 真实模型;
+  // 官方登录档位 raw.env 恒空 → 不注入)。trim + 非空过滤,与上面三字段一致。
+  for (const [k, v] of Object.entries(raw.env ?? {})) {
+    const sv = v?.trim()
+    if (sv) env[k] = sv
+  }
   return env
 }
 

--- a/src/claude-models.ts
+++ b/src/claude-models.ts
@@ -51,6 +51,16 @@ const DEFAULT_CLAUDE_MODELS: Record<string, DefaultClaudeModelConfig> = {
   },
 }
 
+// GLM 档位内置默认别名映射(智谱端点最强组合)。glm 档位 config 未显式配某 env_*
+// 时用这套默认;config 显式配的逐 key 覆盖。让其他机器装新版后 config.toml 只配
+// token 即开箱用,无需手写 env_*。智谱出新模型时改这里 + 发新版即可。
+const DEFAULT_GLM_ENV: Record<string, string> = {
+  ANTHROPIC_DEFAULT_FABLE_MODEL: 'glm-5.2[1m]',
+  ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5.2[1m]',
+  ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5-turbo',
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: 'glm-5-turbo',
+}
+
 function mergedConfig(name: string): ClaudeModelConfig {
   return {
     ...(DEFAULT_CLAUDE_MODELS[name] ?? {}),
@@ -81,6 +91,14 @@ function toProfile(name: string): ClaudeModelProfile | null {
   const raw = mergedConfig(name)
   const key = `claude:${name}`
   const env = envFromConfig(raw)
+  // glm 档位内置默认别名映射(智谱最强组合):仅在 glm 实际配了接入(token)时注入,
+  // config 未配的 key 用默认、显式配的逐 key 覆盖;未配置(token 缺)时不注入(保持
+  // env 空,configured=false 由 picker 拦截)。装新版即开箱用,config.toml 只配 token 即可。
+  if (name === 'glm' && (env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_API_KEY)) {
+    for (const [k, v] of Object.entries(DEFAULT_GLM_ENV)) {
+      if (!(k in env)) env[k] = v
+    }
+  }
   // route:显式 config > 内建默认 > 由是否配了接入信息推断。
   const route: 'login' | 'api' =
     raw.route === 'api' || raw.route === 'login'

--- a/src/claude-models.ts
+++ b/src/claude-models.ts
@@ -6,11 +6,21 @@ export interface ClaudeModelProfile {
   displayName: string
   description: string
   sdkModel: string
+  /** 'login' = 走用户的 Anthropic Claude 登录态,绝不注入 API key(官方
+   * Fable 5/Opus);'api' = 第三方路由(GLM),需 base_url + auth_token。 */
+  route: 'login' | 'api'
+  /** spawn 时注入的 ANTHROPIC_* env 覆盖。login 档位恒为空;api 档位配好
+   * 后为 { ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN[, ANTHROPIC_API_KEY] }。 */
+  env: Record<string, string>
+  /** login 恒 true;api 需 base_url + auth_token 都配好才 true。 */
+  configured: boolean
 }
 
+// 内建默认档位:display_name/description 必填,model/route 可选。
+// login 档位(缺省 route)走登录态;api 档位(route:'api',如 glm)需配 token。
 type DefaultClaudeModelConfig = Required<
   Pick<ClaudeModelConfig, 'display_name' | 'description'>
->
+> & Pick<ClaudeModelConfig, 'model' | 'route'>
 
 // 未在 config.toml [claude.models.*] 指定 model 时的默认档位。
 // Fable 5 是 Anthropic 当前最强模型(1M ctx / 128K out),官方 API 路由可用;
@@ -18,12 +28,25 @@ type DefaultClaudeModelConfig = Required<
 export const DEFAULT_CLAUDE_SDK_MODEL = 'claude-fable-5'
 
 const DEFAULT_CLAUDE_MODELS: Record<string, DefaultClaudeModelConfig> = {
+  // 第一方 Anthropic 档位:model id 直传 Claude Code(reclaude → --model),
+  // 走用户的 Claude 登录态。飞书 model 面板从这里取名。
+  fable: {
+    display_name: 'Claude Code · Fable 5',
+    description: 'Anthropic Fable 5,1M 上下文,当前最强通用模型。',
+    model: 'claude-fable-5',
+  },
+  opus: {
+    display_name: 'Claude Code · Opus 4.8',
+    description: 'Anthropic Opus 4.8,1M 上下文,擅长架构与深度分析。',
+    model: 'claude-opus-4-8',
+  },
   glm: {
     display_name: 'Claude Code · GLM',
-    description: '使用 GLM 路由，适合中文交流和通用编码任务。',
-    // 模型名路由(GLM-5.2[1m] / GLM-4.7)完全靠 ~/.claude/settings.json 的
-    // ANTHROPIC_DEFAULT_*_MODEL,lodestar 不再重复声明。上下文窗口分母纯信
-    // SDK modelUsage 上报的 contextWindow,不在此声明假窗口。
+    description: 'GLM 第三方路由(智谱等)。需在 config.toml 配置 token。',
+    route: 'api',
+    // GLM 的 base_url / auth_token / model 由 [claude.models.glm] 提供,
+    // 不写死在代码里(避免 GLM 版本过期 + token 入库)。未配置时该档位
+    // 在 picker 里可见但选择被拦截,提示去 config.toml 设置。
   },
 }
 
@@ -34,15 +57,42 @@ function mergedConfig(name: string): ClaudeModelConfig {
   }
 }
 
+/** 从档位 config 拼 spawn 用的 ANTHROPIC_* env 覆盖。只在真配了值时才写入
+ * 对应 key —— 空值不写,避免用空串顶掉登录态。 */
+function envFromConfig(raw: ClaudeModelConfig): Record<string, string> {
+  const env: Record<string, string> = {}
+  const baseUrl = raw.base_url?.trim()
+  const authToken = raw.auth_token?.trim()
+  const apiKey = raw.api_key?.trim()
+  if (baseUrl) env.ANTHROPIC_BASE_URL = baseUrl
+  if (authToken) env.ANTHROPIC_AUTH_TOKEN = authToken
+  if (apiKey) env.ANTHROPIC_API_KEY = apiKey
+  return env
+}
+
 function toProfile(name: string): ClaudeModelProfile | null {
   const raw = mergedConfig(name)
   const key = `claude:${name}`
+  const env = envFromConfig(raw)
+  // route:显式 config > 内建默认 > 由是否配了接入信息推断。
+  const route: 'login' | 'api' =
+    raw.route === 'api' || raw.route === 'login'
+      ? raw.route
+      : Object.keys(env).length > 0 ? 'api' : 'login'
+  // login 恒就绪;api 需 base_url + auth_token 都在(api_key 单独也算,GLM 用
+  // auth_token,少数三方用 api_key)。
+  const configured =
+    route === 'login' ||
+    (!!env.ANTHROPIC_BASE_URL && (!!env.ANTHROPIC_AUTH_TOKEN || !!env.ANTHROPIC_API_KEY))
   return {
     key,
     name,
     displayName: raw.display_name?.trim() || `Claude Code · ${name}`,
     description: raw.description?.trim() || `使用 ${name} 路由运行 Claude Code 后端。`,
     sdkModel: raw.model?.trim() || DEFAULT_CLAUDE_SDK_MODEL,
+    route,
+    env,
+    configured,
   }
 }
 
@@ -73,4 +123,24 @@ export function resolveClaudeSdkModel(model: string | null | undefined): string 
   if (profile) return profile.sdkModel
   const stripped = model.startsWith('claude:') ? model.slice('claude:'.length) : model
   return stripped === 'default' ? DEFAULT_CLAUDE_SDK_MODEL : stripped
+}
+
+/** spawn 时要为该档位注入的 ANTHROPIC_* env 覆盖。官方登录档位(Fable 5/
+ * Opus)恒返回空对象 —— 它们绝不走 API key,只用用户的 Claude 登录态。
+ * 只有配好 token 的第三方路由(GLM)才返回非空。 */
+export function claudeModelEnv(model: string | null | undefined): Record<string, string> {
+  return claudeModelProfile(model)?.env ?? {}
+}
+
+/** 该档位是否为第三方 API 路由(GLM 一类)。true = 需要 token 且 spawn 时
+ * 注入 env;false = 官方登录档位(默认档位也算 login)。 */
+export function claudeModelIsApiRoute(model: string | null | undefined): boolean {
+  return claudeModelProfile(model)?.route === 'api'
+}
+
+/** 该档位是否可用:登录档位恒 true;API 路由需 token 配好才 true。 */
+export function claudeModelConfigured(model: string | null | undefined): boolean {
+  const profile = claudeModelProfile(model)
+  // 未知/默认档位当作登录态就绪。
+  return profile ? profile.configured : true
 }

--- a/src/config-parse.ts
+++ b/src/config-parse.ts
@@ -1,0 +1,68 @@
+/** Claude 档位配置的纯类型与纯解析函数,从 config.ts 拆出。
+ *
+ *  拆分原因:多个测试文件用 `mock.module('./config')` 替换 config 单例做隔离,
+ *  而 bun 的模块 mock 无法被 mock.restore() 撤销 —— 在显式多文件同批运行
+ *  (`bun test a.test.ts b.test.ts`)时会泄漏到同作用域其他文件,导致从 './config'
+ *  真实导入 parseClaudeModelProfile 的测试(config.test.ts)拿到被 mock 后的残缺
+ *  对象而抛 SyntaxError。把纯函数 + 它依赖的 type 放到这个不依赖 config 单例的
+ *  独立模块,解析逻辑的单测改从 './config-parse' 导入,即不受 './config' mock
+ *  影响。config.ts 仍 re-export 两者,对外 API 不变。 */
+
+export interface ClaudeModelConfig {
+  display_name?: string
+  description?: string
+  model?: string
+  /** 第三方路由(如 GLM)的接入配置。官方 Anthropic 档位(Fable 5/Opus)
+   * 留空 —— 它们走用户的 Claude 登录态,绝不注入 API key。设置任一即视为
+   * API 路由:spawn 时按档位注入对应 ANTHROPIC_* env(见 claude-models.ts
+   * claudeModelEnv)。GLM 的 token 应放在 [claude.models.glm] 这个档位节里,
+   * 不要放全局 [claude.env],否则会污染官方登录档位。 */
+  base_url?: string
+  auth_token?: string
+  api_key?: string
+  /** 显式声明路由类型;缺省时由是否配置了 base_url/auth_token 推断。 */
+  route?: 'login' | 'api'
+  /** 该档位在 model 面板锁死的思考强度(low/medium/high/xhigh/max)。第三方
+   * 路由(GLM)用它复刻各自最优配置 —— 如 GLM-5.2 直连智谱走 xhigh 触发
+   * extended thinking。官方档位不读此字段(锁 max)。非法值忽略、回落固定值。 */
+  effort?: string
+  /** Per-档位 env 注入(仅 API 路由档位生效)。config 里用扁平标量 env_<NAME>
+   *  表达(本解析器只支持 scalar),如 env_ANTHROPIC_DEFAULT_OPUS_MODEL。
+   *  spawn 时合并进档位 env:选 GLM 时注入别名→GLM 模型映射,官方登录档位
+   *  raw.env 恒空→不注入→三档别名走 Claude Code 默认解析,零污染。
+   *  注意:env 非空会让 toProfile 把 route 推断为 'api',故 env_* 只能配在
+   *  已配 base_url/auth_token 的第三方档位(如 glm),不可配官方登录档位。 */
+  env?: Record<string, string>
+}
+
+/** 从单个 [claude.models.<name>] section 组装 ClaudeModelConfig。
+ *  env_<NAME> 扁平标量收进 profile.env(绕过手写解析器对嵌套 table 的不支持)。
+ *  放在独立模块(而非 config.ts)便于单测解析逻辑,且不受测试里
+ *  mock.module('./config') 的污染影响(见文件头说明)。 */
+export function parseClaudeModelProfile(section: Record<string, unknown>): ClaudeModelConfig {
+  const profile: ClaudeModelConfig = {}
+  for (const [rawKey, value] of Object.entries(section)) {
+    if (typeof value !== 'string' || value.length === 0) continue
+    const field = rawKey.trim()
+    if (field.startsWith('env_')) {
+      const envKey = field.slice(4)
+      if (envKey) {
+        ;((profile.env ??= {}) as Record<string, string>)[envKey] = value
+      }
+      continue
+    }
+    if (
+      field === 'display_name' ||
+      field === 'description' ||
+      field === 'model' ||
+      field === 'base_url' ||
+      field === 'auth_token' ||
+      field === 'api_key' ||
+      field === 'route' ||
+      field === 'effort'
+    ) {
+      ;(profile as Record<string, string>)[field] = value
+    }
+  }
+  return profile
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+import { parseClaudeModelProfile } from './config'
+
+describe('parseClaudeModelProfile', () => {
+  test('env_<NAME> 扁平标量收进 profile.env', () => {
+    const profile = parseClaudeModelProfile({
+      model: 'glm-5.2[1m]',
+      base_url: 'https://open.bigmodel.cn/api/anthropic',
+      auth_token: 'tok',
+      effort: 'xhigh',
+      env_ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5.2[1m]',
+      env_ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5-turbo',
+    })
+    expect(profile.model).toBe('glm-5.2[1m]')
+    expect(profile.base_url).toBe('https://open.bigmodel.cn/api/anthropic')
+    expect(profile.env).toEqual({
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5.2[1m]',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5-turbo',
+    })
+  })
+
+  test('env_ 空值过滤、env_ 后无名为空不收、非 env_ 字段不受影响', () => {
+    const profile = parseClaudeModelProfile({
+      model: 'glm-5.2',
+      env_ANTHROPIC_DEFAULT_HAIKU_MODEL: '', // 空值不收
+      env_: 'nope', // env_ 后为空不收
+      description: 'x',
+    })
+    expect(profile.env).toBeUndefined()
+    expect(profile.description).toBe('x')
+    expect(profile.model).toBe('glm-5.2')
+  })
+})

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { parseClaudeModelProfile } from './config'
+import { parseClaudeModelProfile } from './config-parse'
 
 describe('parseClaudeModelProfile', () => {
   test('env_<NAME> 扁平标量收进 profile.env', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,10 @@ export interface ClaudeModelConfig {
   api_key?: string
   /** 显式声明路由类型;缺省时由是否配置了 base_url/auth_token 推断。 */
   route?: 'login' | 'api'
+  /** 该档位在 model 面板锁死的思考强度(low/medium/high/xhigh/max)。第三方
+   * 路由(GLM)用它复刻各自最优配置 —— 如 GLM-5.2 直连智谱走 xhigh 触发
+   * extended thinking。官方档位不读此字段(锁 max)。非法值忽略、回落固定值。 */
+  effort?: string
 }
 
 /** Per-project agent launch profile, sourced from `[projects.<name>].*`
@@ -175,7 +179,8 @@ function loadConfig(): LodestarConfig {
           field === 'base_url' ||
           field === 'auth_token' ||
           field === 'api_key' ||
-          field === 'route'
+          field === 'route' ||
+          field === 'effort'
         ) {
           ;(profile as Record<string, string>)[field] = value
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,10 @@
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { CONFIG_FILE } from './paths'
+// 纯类型/纯解析从 ./config-parse 引入并对外再导出(保持 './config' 公开 API 不变)。
+// 拆分是为了让解析逻辑的单测可从 './config-parse' 导入,不受 mock.module('./config') 污染。
+import { parseClaudeModelProfile, type ClaudeModelConfig } from './config-parse'
+export { parseClaudeModelProfile, type ClaudeModelConfig }
 
 export interface LodestarConfig {
   feishu: {
@@ -51,33 +55,6 @@ export interface LodestarConfig {
   /** Per-project launch profiles keyed by session name (= group name).
    * Empty record ⇒ every project runs with Lodestar defaults. */
   projects: Record<string, ProjectProfile>
-}
-
-export interface ClaudeModelConfig {
-  display_name?: string
-  description?: string
-  model?: string
-  /** 第三方路由(如 GLM)的接入配置。官方 Anthropic 档位(Fable 5/Opus)
-   * 留空 —— 它们走用户的 Claude 登录态,绝不注入 API key。设置任一即视为
-   * API 路由:spawn 时按档位注入对应 ANTHROPIC_* env(见 claude-models.ts
-   * claudeModelEnv)。GLM 的 token 应放在 [claude.models.glm] 这个档位节里,
-   * 不要放全局 [claude.env],否则会污染官方登录档位。 */
-  base_url?: string
-  auth_token?: string
-  api_key?: string
-  /** 显式声明路由类型;缺省时由是否配置了 base_url/auth_token 推断。 */
-  route?: 'login' | 'api'
-  /** 该档位在 model 面板锁死的思考强度(low/medium/high/xhigh/max)。第三方
-   * 路由(GLM)用它复刻各自最优配置 —— 如 GLM-5.2 直连智谱走 xhigh 触发
-   * extended thinking。官方档位不读此字段(锁 max)。非法值忽略、回落固定值。 */
-  effort?: string
-  /** Per-档位 env 注入(仅 API 路由档位生效)。config 里用扁平标量 env_<NAME>
-   *  表达(本解析器只支持 scalar),如 env_ANTHROPIC_DEFAULT_OPUS_MODEL。
-   *  spawn 时合并进档位 env:选 GLM 时注入别名→GLM 模型映射,官方登录档位
-   *  raw.env 恒空→不注入→三档别名走 Claude Code 默认解析,零污染。
-   *  注意:env 非空会让 toProfile 把 route 推断为 'api',故 env_* 只能配在
-   *  已配 base_url/auth_token 的第三方档位(如 glm),不可配官方登录档位。 */
-  env?: Record<string, string>
 }
 
 /** Per-project agent launch profile, sourced from `[projects.<name>].*`
@@ -132,37 +109,6 @@ function parseToml(text: string): Record<string, Record<string, string>> {
     }
   }
   return out
-}
-
-/** 从单个 [claude.models.<name>] section 组装 ClaudeModelConfig。
- *  env_<NAME> 扁平标量收进 profile.env(绕过手写解析器对嵌套 table 的不支持)。
- *  Export 出来便于单测解析逻辑(否则只能经 loadConfig 全链路间接测)。 */
-export function parseClaudeModelProfile(section: Record<string, unknown>): ClaudeModelConfig {
-  const profile: ClaudeModelConfig = {}
-  for (const [rawKey, value] of Object.entries(section)) {
-    if (typeof value !== 'string' || value.length === 0) continue
-    const field = rawKey.trim()
-    if (field.startsWith('env_')) {
-      const envKey = field.slice(4)
-      if (envKey) {
-        ;((profile.env ??= {}) as Record<string, string>)[envKey] = value
-      }
-      continue
-    }
-    if (
-      field === 'display_name' ||
-      field === 'description' ||
-      field === 'model' ||
-      field === 'base_url' ||
-      field === 'auth_token' ||
-      field === 'api_key' ||
-      field === 'route' ||
-      field === 'effort'
-    ) {
-      ;(profile as Record<string, string>)[field] = value
-    }
-  }
-  return profile
 }
 
 function loadConfig(): LodestarConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,16 @@ export interface ClaudeModelConfig {
   display_name?: string
   description?: string
   model?: string
+  /** 第三方路由(如 GLM)的接入配置。官方 Anthropic 档位(Fable 5/Opus)
+   * 留空 —— 它们走用户的 Claude 登录态,绝不注入 API key。设置任一即视为
+   * API 路由:spawn 时按档位注入对应 ANTHROPIC_* env(见 claude-models.ts
+   * claudeModelEnv)。GLM 的 token 应放在 [claude.models.glm] 这个档位节里,
+   * 不要放全局 [claude.env],否则会污染官方登录档位。 */
+  base_url?: string
+  auth_token?: string
+  api_key?: string
+  /** 显式声明路由类型;缺省时由是否配置了 base_url/auth_token 推断。 */
+  route?: 'login' | 'api'
 }
 
 /** Per-project agent launch profile, sourced from `[projects.<name>].*`
@@ -161,7 +171,11 @@ function loadConfig(): LodestarConfig {
         if (
           field === 'display_name' ||
           field === 'description' ||
-          field === 'model'
+          field === 'model' ||
+          field === 'base_url' ||
+          field === 'auth_token' ||
+          field === 'api_key' ||
+          field === 'route'
         ) {
           ;(profile as Record<string, string>)[field] = value
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,13 @@ export interface ClaudeModelConfig {
    * 路由(GLM)用它复刻各自最优配置 —— 如 GLM-5.2 直连智谱走 xhigh 触发
    * extended thinking。官方档位不读此字段(锁 max)。非法值忽略、回落固定值。 */
   effort?: string
+  /** Per-档位 env 注入(仅 API 路由档位生效)。config 里用扁平标量 env_<NAME>
+   *  表达(本解析器只支持 scalar),如 env_ANTHROPIC_DEFAULT_OPUS_MODEL。
+   *  spawn 时合并进档位 env:选 GLM 时注入别名→GLM 模型映射,官方登录档位
+   *  raw.env 恒空→不注入→三档别名走 Claude Code 默认解析,零污染。
+   *  注意:env 非空会让 toProfile 把 route 推断为 'api',故 env_* 只能配在
+   *  已配 base_url/auth_token 的第三方档位(如 glm),不可配官方登录档位。 */
+  env?: Record<string, string>
 }
 
 /** Per-project agent launch profile, sourced from `[projects.<name>].*`
@@ -127,6 +134,37 @@ function parseToml(text: string): Record<string, Record<string, string>> {
   return out
 }
 
+/** 从单个 [claude.models.<name>] section 组装 ClaudeModelConfig。
+ *  env_<NAME> 扁平标量收进 profile.env(绕过手写解析器对嵌套 table 的不支持)。
+ *  Export 出来便于单测解析逻辑(否则只能经 loadConfig 全链路间接测)。 */
+export function parseClaudeModelProfile(section: Record<string, unknown>): ClaudeModelConfig {
+  const profile: ClaudeModelConfig = {}
+  for (const [rawKey, value] of Object.entries(section)) {
+    if (typeof value !== 'string' || value.length === 0) continue
+    const field = rawKey.trim()
+    if (field.startsWith('env_')) {
+      const envKey = field.slice(4)
+      if (envKey) {
+        ;((profile.env ??= {}) as Record<string, string>)[envKey] = value
+      }
+      continue
+    }
+    if (
+      field === 'display_name' ||
+      field === 'description' ||
+      field === 'model' ||
+      field === 'base_url' ||
+      field === 'auth_token' ||
+      field === 'api_key' ||
+      field === 'route' ||
+      field === 'effort'
+    ) {
+      ;(profile as Record<string, string>)[field] = value
+    }
+  }
+  return profile
+}
+
 function loadConfig(): LodestarConfig {
   let raw: string
   try {
@@ -168,24 +206,7 @@ function loadConfig(): LodestarConfig {
       if (!sectionName.startsWith(prefix)) continue
       const key = sectionName.slice(prefix.length).trim()
       if (!key) continue
-      const profile: ClaudeModelConfig = {}
-      for (const [rawKey, value] of Object.entries(section)) {
-        if (typeof value !== 'string' || value.length === 0) continue
-        const field = rawKey.trim()
-        if (
-          field === 'display_name' ||
-          field === 'description' ||
-          field === 'model' ||
-          field === 'base_url' ||
-          field === 'auth_token' ||
-          field === 'api_key' ||
-          field === 'route' ||
-          field === 'effort'
-        ) {
-          ;(profile as Record<string, string>)[field] = value
-        }
-      }
-      out[key] = profile
+      out[key] = parseClaudeModelProfile(section)
     }
     return out
   }

--- a/src/session-model.ts
+++ b/src/session-model.ts
@@ -106,7 +106,7 @@ export function normalizeFixedModelSelection(
 /** 第三方 API 路由(GLM)未配 token 时的描述后缀,提示去 config.toml 设置。 */
 function choiceDescription(item: typeof FIXED_MODEL_CHOICES[number]): string {
   if (item.provider === 'claude' && claudeModelIsApiRoute(item.model) && !claudeModelConfigured(item.model)) {
-    return `${item.description}(未配置 · 需在 config.toml 的 [claude.models.glm] 填 base_url + auth_token)`
+    return `${item.description}(未配置 · 需在 config.toml 的 [claude.models.glm] 填 base_url + auth_token + model)`
   }
   return item.description
 }
@@ -225,7 +225,7 @@ export async function onModelEffortSelect(
   if (provider === 'claude' && claudeModelIsApiRoute(model) && !claudeModelConfigured(model)) {
     return {
       ok: false,
-      message: `GLM(${model})未配置:请在 ~/.config/lodestar/config.toml 的 [claude.models.glm] 填写 base_url 和 auth_token 后重试(官方 Fable 5 / Opus 走登录态,无需配置)`,
+      message: `GLM(${model})未配置:请在 ~/.config/lodestar/config.toml 的 [claude.models.glm] 填写 base_url、auth_token 和 model 后重试(官方 Fable 5 / Opus 走登录态,无需配置)`,
     }
   }
   const choice = panel?.models.find(m => m.model === model && (m.provider ?? 'codex') === provider)

--- a/src/session-model.ts
+++ b/src/session-model.ts
@@ -11,7 +11,7 @@ import {
 } from './agent-process'
 import * as cards from './cards'
 import * as feishu from './feishu'
-import { claudeModelConfigured, claudeModelIsApiRoute } from './claude-models'
+import { claudeModelConfigured, claudeModelEffort, claudeModelIsApiRoute } from './claude-models'
 import { log } from './log'
 import { messageOf, withTimeout, type ModelActionResult } from './session-util'
 
@@ -66,6 +66,17 @@ function defaultFixedChoiceFor(provider: AgentProvider): typeof FIXED_MODEL_CHOI
   return FIXED_MODEL_CHOICES.find(c => c.provider === provider) ?? FIXED_MODEL_CHOICES[0]
 }
 
+/** 档位实际锁死的 effort:第三方路由(GLM)优先用 config 声明的 effort
+ * (如 xhigh 复刻智谱最高思维),否则回落到 FIXED_MODEL_CHOICES 的默认值。
+ * picker 渲染、选择校验、归一化都走这里,保持三处一致。 */
+function resolvedEffort(item: typeof FIXED_MODEL_CHOICES[number]): AgentReasoningEffort {
+  if (item.provider === 'claude') {
+    const configured = claudeModelEffort(item.model)
+    if (configured) return configured
+  }
+  return item.effort
+}
+
 /** 把持久化的 (provider, model, effort) 归一到当前固定选项集。
  *   - 命中固定项 → 原样保留(强制该项锁死的 effort)。
  *   - legacy/退役 model(如 claude:glm、claude:deepseek)→ 回落到该 provider
@@ -86,10 +97,10 @@ export function normalizeFixedModelSelection(
   // 的 GLM 正常保留 —— 满足"别丢 GLM 设置"。
   if (hit && provider === 'claude' && claudeModelIsApiRoute(model) && !claudeModelConfigured(model)) {
     const fallback = defaultFixedChoiceFor(provider)
-    return { model: fallback.model, effort: fallback.effort }
+    return { model: fallback.model, effort: resolvedEffort(fallback) }
   }
   const choice = hit ?? defaultFixedChoiceFor(provider)
-  return { model: choice.model, effort: choice.effort }
+  return { model: choice.model, effort: resolvedEffort(choice) }
 }
 
 /** 第三方 API 路由(GLM)未配 token 时的描述后缀,提示去 config.toml 设置。 */
@@ -106,6 +117,7 @@ export function fixedModelChoices(s: Session): cards.ModelChoice[] {
   const currentEffort = s.currentEffortLabel()
   return FIXED_MODEL_CHOICES.map(item => {
     const selected = currentProvider === item.provider && currentModel === item.model
+    const effort = resolvedEffort(item)
     return {
       provider: item.provider,
       model: item.model,
@@ -114,10 +126,10 @@ export function fixedModelChoices(s: Session): cards.ModelChoice[] {
       isDefault: false,
       selected,
       efforts: [{
-        effort: item.effort,
+        effort,
         description: '',
         isDefault: true,
-        selected: selected && currentEffort === item.effort,
+        selected: selected && currentEffort === effort,
       }],
     }
   })
@@ -205,7 +217,7 @@ export async function onModelEffortSelect(
   // 二元锁死:只放行 FIXED_MODEL_CHOICES 的 (provider, model, effort) 组合,
   // 拒绝旧 effort 回调/伪造把 session 切到非固定项或非锁死 effort。
   const fixed = FIXED_MODEL_CHOICES.find(c => c.provider === provider && c.model === model)
-  if (!fixed || fixed.effort !== effort) {
+  if (!fixed || resolvedEffort(fixed) !== effort) {
     return { ok: false, message: `${agentProviderLabel(provider)} · ${model}/${effort} 不在固定选项中` }
   }
   // 第三方 API 路由(GLM)必须先在 lodestar config 配好 token 才能切换 ——

--- a/src/session-model.ts
+++ b/src/session-model.ts
@@ -11,6 +11,7 @@ import {
 } from './agent-process'
 import * as cards from './cards'
 import * as feishu from './feishu'
+import { claudeModelConfigured, claudeModelIsApiRoute } from './claude-models'
 import { log } from './log'
 import { messageOf, withTimeout, type ModelActionResult } from './session-util'
 
@@ -18,10 +19,13 @@ export interface ModelPanelState {
   models: cards.ModelChoice[]
 }
 
-/** model 命令的二元固定选项:effort 锁死,选了即生效(无 effort 二级面板)。
- * codex = gpt-5.5 / xhigh;claude = claude:glm (GLM-5.2) / max (ultracode)。
- * claude 的 max 由 ClaudeAgentProcess.setModelSettings 强制 applyFlagSettings,
- * 不依赖 ~/.claude/settings.json 的 effortLevel。 */
+/** model 命令的固定选项:每项 effort 锁死,选了即生效(无 effort 二级面板)。
+ * codex = gpt-5.5 / xhigh;claude 第一方档位 = Fable 5 / Opus 4.8,均 max
+ * (ultracode 最高思考强度)。claude 的 max 由 ClaudeAgentProcess.setModelSettings
+ * 强制 applyFlagSettings,不依赖 ~/.claude/settings.json 的 effortLevel。
+ * 各 claude:<key> 的实际 SDK model id 由 claude-models.ts 的 profile 决定
+ * (claude:fable→claude-fable-5,claude:opus→claude-opus-4-8),reclaude 透传
+ * --model 到 Claude Code,走用户的 Anthropic 登录态。 */
 const FIXED_MODEL_CHOICES = [
   {
     provider: 'codex' as const,
@@ -32,14 +36,71 @@ const FIXED_MODEL_CHOICES = [
   },
   {
     provider: 'claude' as const,
+    model: 'claude:fable',
+    displayName: 'Claude · Fable 5',
+    description: 'Fable 5 · max (ultracode) · 1M 上下文,当前最强通用模型。',
+    effort: 'max' as AgentReasoningEffort,
+  },
+  {
+    provider: 'claude' as const,
+    model: 'claude:opus',
+    displayName: 'Claude · Opus 4.8',
+    description: 'Opus 4.8 · max (ultracode) · 1M 上下文,擅长架构与深度分析。',
+    effort: 'max' as AgentReasoningEffort,
+  },
+  {
+    // GLM 第三方路由:走 config.toml [claude.models.glm] 的 base_url + auth_token,
+    // 不用官方登录态。未配置 token 时 picker 仍显示(描述提示去配置),但选择
+    // 会被 onModelEffortSelect 拦截。
+    provider: 'claude' as const,
     model: 'claude:glm',
-    displayName: 'Claude · GLM-5.2',
-    description: 'GLM-5.2 · max (ultracode) 推理强度。',
+    displayName: 'Claude · GLM',
+    description: 'GLM 第三方路由 · max。',
     effort: 'max' as AgentReasoningEffort,
   },
 ]
 
-function fixedModelChoices(s: Session): cards.ModelChoice[] {
+/** provider 的默认固定档位(该 provider 的第一个固定项)。归一化未知/退役
+ * 选择时回落到它。 */
+function defaultFixedChoiceFor(provider: AgentProvider): typeof FIXED_MODEL_CHOICES[number] {
+  return FIXED_MODEL_CHOICES.find(c => c.provider === provider) ?? FIXED_MODEL_CHOICES[0]
+}
+
+/** 把持久化的 (provider, model, effort) 归一到当前固定选项集。
+ *   - 命中固定项 → 原样保留(强制该项锁死的 effort)。
+ *   - legacy/退役 model(如 claude:glm、claude:deepseek)→ 回落到该 provider
+ *     的默认固定项(claude→claude:fable,底层同为 claude-fable-5,行为不变,
+ *     只是把误导性的 GLM 标签迁移成准确的 Fable 5)。
+ * daemon 重启后 restoreModelSelection 用它,避免旧 map 把 session 带到已
+ * 下线的档位或非锁死 effort。 */
+export function normalizeFixedModelSelection(
+  provider: AgentProvider,
+  model: string | null | undefined,
+  _effort: AgentReasoningEffort | null | undefined,
+): { model: string; effort: AgentReasoningEffort } {
+  const hit = FIXED_MODEL_CHOICES.find(c => c.provider === provider && c.model === model)
+  // 第三方 API 路由(GLM)持久化了但当前未配置 token → 回落到该 provider 的
+  // 登录默认档位(claude:fable)。否则启动 restore 会以未鉴权状态拉起该档位:
+  // 既跑不通(resolveClaudeSdkModel 回落到官方 model id 打第三方端点),又
+  // 绕过了 picker 的配置门槛(restore 不走 onModelEffortSelect)。配好 token
+  // 的 GLM 正常保留 —— 满足"别丢 GLM 设置"。
+  if (hit && provider === 'claude' && claudeModelIsApiRoute(model) && !claudeModelConfigured(model)) {
+    const fallback = defaultFixedChoiceFor(provider)
+    return { model: fallback.model, effort: fallback.effort }
+  }
+  const choice = hit ?? defaultFixedChoiceFor(provider)
+  return { model: choice.model, effort: choice.effort }
+}
+
+/** 第三方 API 路由(GLM)未配 token 时的描述后缀,提示去 config.toml 设置。 */
+function choiceDescription(item: typeof FIXED_MODEL_CHOICES[number]): string {
+  if (item.provider === 'claude' && claudeModelIsApiRoute(item.model) && !claudeModelConfigured(item.model)) {
+    return `${item.description}(未配置 · 需在 config.toml 的 [claude.models.glm] 填 base_url + auth_token)`
+  }
+  return item.description
+}
+
+export function fixedModelChoices(s: Session): cards.ModelChoice[] {
   const currentProvider = s.currentProvider()
   const currentModel = s.currentModelLabel()
   const currentEffort = s.currentEffortLabel()
@@ -49,7 +110,7 @@ function fixedModelChoices(s: Session): cards.ModelChoice[] {
       provider: item.provider,
       model: item.model,
       displayName: item.displayName,
-      description: item.description,
+      description: choiceDescription(item),
       isDefault: false,
       selected,
       efforts: [{
@@ -146,6 +207,14 @@ export async function onModelEffortSelect(
   const fixed = FIXED_MODEL_CHOICES.find(c => c.provider === provider && c.model === model)
   if (!fixed || fixed.effort !== effort) {
     return { ok: false, message: `${agentProviderLabel(provider)} · ${model}/${effort} 不在固定选项中` }
+  }
+  // 第三方 API 路由(GLM)必须先在 lodestar config 配好 token 才能切换 ——
+  // 官方登录档位(Fable 5/Opus)无需配置。拦截未配置的 GLM,给出清晰指引。
+  if (provider === 'claude' && claudeModelIsApiRoute(model) && !claudeModelConfigured(model)) {
+    return {
+      ok: false,
+      message: `GLM(${model})未配置:请在 ~/.config/lodestar/config.toml 的 [claude.models.glm] 填写 base_url 和 auth_token 后重试(官方 Fable 5 / Opus 走登录态,无需配置)`,
+    }
   }
   const choice = panel?.models.find(m => m.model === model && (m.provider ?? 'codex') === provider)
   if (choice && !choice.efforts.some(item => item.effort === effort)) {

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -509,6 +509,47 @@ describe('Session provider switching', () => {
     expect(glm.description).toContain('配置')
   })
 
+  test('GLM 档位的 effort 跟随 config(xhigh)而非写死 max;官方档位仍 max', () => {
+    const prev = config.claude.models
+    ;(config.claude as any).models = {
+      glm: { model: 'glm-5.2', base_url: 'https://open.bigmodel.cn/api/anthropic', auth_token: 't', effort: 'xhigh' },
+    }
+    try {
+      const session = new Session('probe', 'chat_id') as any
+      session.selectedProvider = 'claude'
+      const choices = fixedModelChoices(session)
+      const glm = choices.find((c: any) => c.model === 'claude:glm')
+      expect(glm.efforts.map((e: any) => e.effort)).toEqual(['xhigh'])
+      const opus = choices.find((c: any) => c.model === 'claude:opus')
+      expect(opus.efforts.map((e: any) => e.effort)).toEqual(['max'])
+    } finally {
+      ;(config.claude as any).models = prev
+    }
+  })
+
+  test('配好 xhigh 的 GLM:选 xhigh 通过,选 max 因不匹配被拒', async () => {
+    const prev = config.claude.models
+    ;(config.claude as any).models = {
+      glm: { model: 'glm-5.2', base_url: 'https://open.bigmodel.cn/api/anthropic', auth_token: 't', effort: 'xhigh' },
+    }
+    try {
+      const mk = () => {
+        const s = new Session('probe', 'chat_id') as any
+        s.proc = new FakeAgentProc('claude', 'claude-session-1')
+        s.selectedProvider = 'claude'
+        s.selectedModel = 'claude:fable'
+        return s
+      }
+      const ok = await mk().onModelEffortSelect('claude:glm', 'xhigh', '', 'ou_user', 'claude')
+      expect(ok.ok).toBe(true)
+      const bad = await mk().onModelEffortSelect('claude:glm', 'max', '', 'ou_user', 'claude')
+      expect(bad.ok).toBe(false)
+      expect(bad.message).toContain('不在固定选项中')
+    } finally {
+      ;(config.claude as any).models = prev
+    }
+  })
+
   test('未配置 token 时选 GLM 被拦截并提示去 config.toml 设置', async () => {
     const session = new Session('probe', 'chat_id') as any
     const proc = new FakeAgentProc('claude', 'claude-session-1')

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -338,6 +338,45 @@ describe('Session compact command', () => {
   })
 })
 
+describe('Fixed model selection normalization', () => {
+  test('keeps valid first-party Claude choices intact', () => {
+    expect(normalizeFixedModelSelection('claude', 'claude:opus', 'max'))
+      .toEqual({ model: 'claude:opus', effort: 'max' })
+    expect(normalizeFixedModelSelection('claude', 'claude:fable', 'max'))
+      .toEqual({ model: 'claude:fable', effort: 'max' })
+  })
+
+  test('falls an UNCONFIGURED GLM selection back to the login default (Fable 5)', () => {
+    // 无 token 配置时,持久化的 claude:glm 回落到 claude:fable(登录态),
+    // 避免启动以未鉴权状态拉起、且绕过 picker 门槛。
+    expect(normalizeFixedModelSelection('claude', 'claude:glm', 'max'))
+      .toEqual({ model: 'claude:fable', effort: 'max' })
+  })
+
+  test('keeps a CONFIGURED GLM selection intact (不丢用户设好的 GLM)', () => {
+    const prev = config.claude.models
+    ;(config.claude as any).models = {
+      glm: { model: 'glm-4.6', base_url: 'https://glm.example/anthropic', auth_token: 'tok' },
+    }
+    try {
+      expect(normalizeFixedModelSelection('claude', 'claude:glm', 'max'))
+        .toEqual({ model: 'claude:glm', effort: 'max' })
+    } finally {
+      ;(config.claude as any).models = prev
+    }
+  })
+
+  test('resets an unknown/retired Claude model to the Claude default', () => {
+    expect(normalizeFixedModelSelection('claude', 'claude:deepseek', 'high'))
+      .toEqual({ model: 'claude:fable', effort: 'max' })
+  })
+
+  test('normalizes any Codex selection to the fixed GPT-5.5 / xhigh', () => {
+    expect(normalizeFixedModelSelection('codex', 'gpt-4', 'low'))
+      .toEqual({ model: 'gpt-5.5', effort: 'xhigh' })
+  })
+})
+
 describe('Session provider switching', () => {
   test('uses provider-specific ask instructions', () => {
     const session = new Session('probe', 'chat_id') as any
@@ -396,7 +435,7 @@ describe('Session provider switching', () => {
     session.selectedProvider = 'codex'
     session.currentTurn = turnState()
 
-    const result = await session.onModelEffortSelect('claude:glm', 'max', '', 'ou_user', 'claude')
+    const result = await session.onModelEffortSelect('claude:opus', 'max', '', 'ou_user', 'claude')
 
     expect(result.ok).toBe(false)
     expect(result.message).toContain('正在执行或排队')
@@ -411,17 +450,17 @@ describe('Session provider switching', () => {
     session.selectedProvider = 'claude'
     session.selectedModel = 'claude:default'
 
-    const result = await session.onModelEffortSelect('claude:glm', 'max', '', 'ou_user', 'claude')
+    const result = await session.onModelEffortSelect('claude:opus', 'max', '', 'ou_user', 'claude')
 
     expect(result.ok).toBe(true)
-    expect(session.selectedModel).toBe('claude:glm')
+    expect(session.selectedModel).toBe('claude:opus')
     expect(proc.killCalls).toBe(1)
     expect(session.proc).toBeNull()
     expect(proc.setModelSettingsCalls).toEqual([])
     expect(result.card ? JSON.stringify(result.card) : '').toContain('下次启动 Claude')
   })
 
-  test('rejects non-fixed Claude model outside the two fixed choices', async () => {
+  test('rejects non-fixed Claude model outside the fixed choices', async () => {
     const session = new Session('probe', 'chat_id') as any
     const proc = new FakeAgentProc('claude', 'claude-session-1')
     session.proc = proc
@@ -433,6 +472,56 @@ describe('Session provider switching', () => {
     expect(result.ok).toBe(false)
     expect(result.message).toContain('不在固定选项中')
     expect(session.selectedModel).toBe('claude:default')
+    expect(proc.killCalls).toBe(0)
+  })
+
+  test('accepts the first-party Claude Code choices (Opus 4.8 / Fable 5, max)', async () => {
+    for (const model of ['claude:opus', 'claude:fable']) {
+      const session = new Session('probe', 'chat_id') as any
+      const proc = new FakeAgentProc('claude', 'claude-session-1')
+      session.proc = proc
+      session.selectedProvider = 'claude'
+      session.selectedModel = 'claude:default'
+
+      const result = await session.onModelEffortSelect(model, 'max', '', 'ou_user', 'claude')
+
+      expect(result.ok).toBe(true)
+      expect(session.selectedModel).toBe(model)
+      expect(proc.killCalls).toBe(1) // model 变更 → 空闲 Claude 进程重生,新 env 下轮生效
+      expect(session.proc).toBeNull()
+    }
+  })
+
+  test('model 选择器展示 Opus 4.8 / Fable 5 官方档位 + GLM 第三方档位', () => {
+    const session = new Session('probe', 'chat_id') as any
+    session.selectedProvider = 'claude'
+    const choices = fixedModelChoices(session)
+    const claudeModels = choices.filter((c: any) => c.provider === 'claude').map((c: any) => c.model)
+    expect(claudeModels).toContain('claude:opus')
+    expect(claudeModels).toContain('claude:fable')
+    expect(claudeModels).toContain('claude:glm')
+    // 每个 Claude 档位锁死 max 最高思考强度
+    for (const c of choices.filter((c: any) => c.provider === 'claude')) {
+      expect(c.efforts.map((e: any) => e.effort)).toEqual(['max'])
+    }
+    // GLM 未配置 token 时,描述提示需要设置。
+    const glm = choices.find((c: any) => c.model === 'claude:glm')
+    expect(glm.description).toContain('配置')
+  })
+
+  test('未配置 token 时选 GLM 被拦截并提示去 config.toml 设置', async () => {
+    const session = new Session('probe', 'chat_id') as any
+    const proc = new FakeAgentProc('claude', 'claude-session-1')
+    session.proc = proc
+    session.selectedProvider = 'claude'
+    session.selectedModel = 'claude:fable'
+
+    const result = await session.onModelEffortSelect('claude:glm', 'max', '', 'ou_user', 'claude')
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('GLM')
+    expect(result.message).toMatch(/配置|config/)
+    expect(session.selectedModel).toBe('claude:fable') // 未切换
     expect(proc.killCalls).toBe(0)
   })
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -386,17 +386,16 @@ export class Session {
     this.selectedProvider = selection?.provider ?? 'claude'
     this.selectedModel = selection?.model ?? null
     this.selectedEffort = selection?.effort ?? null
-    // model 命令已二元化:历史持久化的非固定值归一到固定两项,避免旧
-    // session-model-map 把 session 带到已下线的 profile(如 claude:deepseek)。
-    // 仅在有持久化选择时归一;无选择(默认)保持 null,交给 spawn 默认逻辑。
+    // 历史持久化的选择归一到当前固定选项集,避免旧 session-model-map 把
+    // session 带到已下线的 profile(如 claude:deepseek)或把 legacy claude:glm
+    // 停在误导标签上(迁移到 claude:fable,底层同为 claude-fable-5)。仅在有
+    // 持久化选择时归一;无选择(默认)保持 null,交给 spawn 默认逻辑。
     if (selection) {
-      if (this.selectedProvider === 'claude' && this.selectedModel !== 'claude:glm') {
-        this.selectedModel = 'claude:glm'
-        this.selectedEffort = 'max'
-      } else if (this.selectedProvider === 'codex' && this.selectedModel !== 'gpt-5.5') {
-        this.selectedModel = 'gpt-5.5'
-        this.selectedEffort = 'xhigh'
-      }
+      const norm = sessionModel.normalizeFixedModelSelection(
+        this.selectedProvider, this.selectedModel, this.selectedEffort,
+      )
+      this.selectedModel = norm.model
+      this.selectedEffort = norm.effort
     }
     if (this.selectedModel) {
       log(`session "${sessionName}": restored selected provider=${this.selectedProvider} model=${this.selectedModel} effort=${this.selectedEffort ?? 'unset'}`)


### PR DESCRIPTION
> ⚠️ **Draft** —— 改动较大且带产品取向(默认模型、第三方 GLM 路由),先开 draft 对齐方向,不急于合并。

## 背景

飞书 model 面板此前是“Codex / 误标 GLM”二元结构。所谓“Claude·GLM-5.2”实为登录态在跑 `claude-fable-5`(误标)—— 这是 Fable 5 额度被悄悄耗尽的根因。

## 改动(3 commit)

1. **`feat(claude): 默认 SDK 模型升至 claude-fable-5`** —— 未显式配 model 的 profile 从 opus 提到 Fable 5(1M ctx / 128K out)。第三方路由不认该 id 的,可在 profile 里显式配 model 覆盖。
2. **`feat(model): 官方 Fable5/Opus4.8 档位 + GLM 第三方 per-model token 路由`** —— 档位带 `route(login/api)` + env + configured:官方 Anthropic 走登录态并锁 max;GLM 走 `[claude.models.glm]` 配置的第三方 token。`buildSpawnEnv` 先无条件抹掉 `ANTHROPIC_BASE_URL / AUTH_TOKEN / API_KEY` 建立干净基线,仅 api 路由注入该档位声明的 env —— 官方绝不夹带 API key(纯登录),GLM 不夹带残留官方 key。
3. **`feat(model): GLM 档位 effort 可配置`** —— `[claude.models.*].effort` 驱动;GLM 复刻 GLM-5.2 xhigh(extended thinking),官方档位仍锁 max。

## 取向 / 待讨论

- 默认模型从 opus 改 Fable 5,是否符合上游预期?
- 是否愿意在主干支持第三方(GLM / 智谱)per-model token 路由,还是保持登录态单一?

若方向 OK,`1` 可单独先合(纯默认值),`2/3` 再议。

## 测试

新增档位解析、per-model env scrub/inject、picker、配置门槛、归一化、effort 校验测试。全量 `bun test`:**269 pass / 0 fail**。

> 注:cherry-pick 到 upstream 时,`session.test.ts` 两行动态 import(`./session-model`、`./config`)因上游该文件结构已分叉,被 3-way merge 静默丢弃(无冲突标记),已在本分支补回。
