### PR TITLE
fix(session): claude rate_limit_event 不再污染 codex 用量缓存

### DIFF
--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -9,6 +9,7 @@ const { Session } = await import('./session')
 const cardkit = await import('./cardkit')
 const { fixedModelChoices, normalizeFixedModelSelection } = await import('./session-model')
 const { config } = await import('./config')
+const { peekUsage, updateUsageFromRateLimits } = await import('./usage')
 
 interface FetchCall {
   method: string
@@ -853,5 +854,41 @@ describe('Session SDK-initiated bg-task resume turns', () => {
 
     expect(session.orphanAssistantSegments).toEqual([])
     expect(session.orphanAssistantCurrent).toBe('')
+  })
+})
+
+describe('Session usage cache cross-backend isolation', () => {
+  test('claude 的 rate_limit_event payload 不得覆盖 codex 用量缓存', () => {
+    // 先用一条 codex 形状的 payload 播种缓存(模块级单例)。
+    const seeded = updateUsageFromRateLimits({
+      planType: 'plus',
+      primary: { usedPercent: 42, resetsAt: 1_700_000_000, windowDurationMins: 300 },
+    })
+    expect(seeded.state).toBe('ok')
+
+    const session = new Session('probe', 'chat_id') as any
+    const claudeProc = new FakeAgentProc('claude')
+    session.wireProc(claudeProc)
+    // claude 的 rate_limit_info 形状(无 planType/primary/secondary):
+    // truthy 但与 codex 完全不同,穿过共享 handler 会被包成空窗口 ok 快照。
+    claudeProc.emit('rate_limits_updated', { status: 'allowed', unified_status: 'allowed' })
+
+    // 缓存对象必须原封不动(恒等,而非结构相等)。
+    expect(peekUsage()).toBe(seeded)
+  })
+
+  test('codex 的 rate_limits_updated 照常更新用量缓存', () => {
+    const session = new Session('probe', 'chat_id') as any
+    const codexProc = new FakeAgentProc('codex')
+    session.wireProc(codexProc)
+    codexProc.emit('rate_limits_updated', {
+      planType: 'pro',
+      primary: { usedPercent: 7, resetsAt: 1_700_000_000, windowDurationMins: 300 },
+    })
+
+    const snap = peekUsage() as any
+    expect(snap?.state).toBe('ok')
+    expect(snap?.subscriptionType).toBe('pro')
+    expect(snap?.fiveHour?.percent).toBe(7)
   })
 })

--- a/src/session.ts
+++ b/src/session.ts
@@ -1803,7 +1803,10 @@ export class Session {
       this.handleContextCompacted(notice)
     })
     p.on('rate_limits_updated', (rateLimits: any) => {
-      updateUsageFromRateLimits(rateLimits)
+      // usage.ts 的缓存是 codex 专属(planType/primary/secondary 形状)。claude
+      // 的 rate_limit_info 形状不同但同样 truthy,写入会把 codex 快照覆盖成
+      // 全 null 的假 ok 数据 —— 只放行 codex 进程的事件。
+      if (p.provider === 'codex') updateUsageFromRateLimits(rateLimits)
     })
     p.on('thread_goal_updated', (goal: ThreadGoal) => {
       this.handleThreadGoalUpdated(goal)


### PR DESCRIPTION
#9 讨论 / #10 RFC 里提到的现存 bug A（P-1a），按承诺独立先修、不等 RFC 定稿。

## 问题

`wireProc` 对 claude/codex 两种进程共用同一个 `rate_limits_updated` handler（`session.ts:1805`），直调 codex 侧的 `updateUsageFromRateLimits`；后者只挡 falsy（`usage.ts:115`）。claude 进程收到 `rate_limit_event` 时 emit 的 `rate_limit_info`（`claude-agent-process.ts:928-929`）形状完全不同（无 `planType/primary/secondary`）但同样 truthy——穿过 handler 后被包成 `{state:'ok', subscriptionType: undefined, fiveHour: null, weekly: null}` 的假快照，**覆盖 codex 的模块级用量缓存**。之后 hi 面板 / turn footer 读到的 codex 额度是被污染的空数据。

跑过 claude 会话的 daemon 里，codex 额度显示随时可能被一次 claude 限流事件打回全 MISS。

## 修复

最小门控：只放行 `p.provider === 'codex'` 的事件进 codex 缓存（缓存本就是 codex 专属语义）。claude 侧的官方订阅额度如何利用这条事件流，是 #10 P4 `anthropic-subscription` 适配器的事——本 PR 不引入新行为。

## 测试

TDD：先写失败测试复现（用恒等断言锁缓存对象不被替换；正向对照确认 codex 事件照常更新），修复后转绿。全量 `bun test`：**262 pass / 0 fail**。
