### PR TITLE
feat(model): setting_sources 加 "auto" 智能档 —— 自动识别项目 .claude/CLAUDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,17 @@ keep_lodestar_instructions = "true"
 | 字段 | 作用 | 默认 |
 | --- | --- | --- |
 | `cwd` | agent 工作目录(绝对路径) | `projects_root/<群名>` |
-| `setting_sources` | `project` 只读项目级设置,不加载用户级全局插件/技能 | `user` |
+| `setting_sources` | `auto`(推荐)检测到项目 `.claude/` 或 `CLAUDE.md` 就自动 `user,project,local`、否则退回 `user`(始终含 `user`,不卡死);`project` 只读项目级设置,不加载用户级全局插件/技能;也可显式逗号列表 | `user` |
 | `strict_mcp` | 只挂下方项目 MCP,忽略全局 MCP | 关 |
 | `tools` | 允许的内置工具(逗号分隔);MCP 工具由 `load_project_mcp` 自动可用,不用列在这里 | claude_code 全套 |
 | `load_project_mcp` | 读取 `<cwd>/.mcp.json` 并挂载其 MCP 服务 | 关 |
 | `keep_lodestar_instructions` | 保留夜航星卡片/输出约定系统提示 | 开 |
 
 `strict_mcp = "true"` 时,项目 `.mcp.json` 是 agent 能挂上 MCP 的唯一通路 —— 全局插件/技能被全部挡掉,agent 干净专注。典型用法:外部自动化引擎在自己的目录里维护规则文件,夜航星负责飞书通道和卡片渲染,两者通过群消息驱动协作。
+
+> 💡 **`setting_sources = "auto"`** 是"像在项目目录里直接启动 claude code"的推荐档:cwd 有 `.claude/` 或 `CLAUDE.md` 就自动 `user,project,local`(项目 `CLAUDE.md` / skills / agents / `settings.json` 全生效),否则退回 `user`。两个分支都含 `user`,不会踩下面 `project` 那个卡死坑。仅对 **Claude 引擎**有效(Codex 无论如何自动读 `AGENTS.md`)。
+>
+> ⚠️ 命中后会**整体加载**项目 `.claude/settings.json` 的 hooks(`SessionStart`/`UserPromptSubmit`/`PreToolUse`/`Stop`),每轮在 daemon 内执行且无 TTY 回显 —— `PreToolUse` hook 退出非零会**拦掉该次工具调用**;`settingSources` 全有全无,无法只要 skills/agents 而摘掉 hooks。接入前先审项目 hooks 是否会在自动化通道阻塞。
 
 > ⚠️ **这组配置必须完整,配一半会把对话卡死。** `[projects.*]` 的字段是联动的,任一项开启后,它依赖的链路都要一起配齐:
 >

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -1,7 +1,7 @@
 import { homedir, tmpdir } from 'node:os'
-import { mkdtempSync, writeFileSync, unlinkSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, unlinkSync, rmSync } from 'node:fs'
 import { delimiter, join, win32 } from 'node:path'
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
 
 mock.module('./config', () => ({
   config: {
@@ -825,6 +825,18 @@ describe('Claude transcript context tokens', () => {
 })
 
 describe('Claude project profile overrides', () => {
+  const ssTmpDirs: string[] = []
+  function tmpProjectDir(entries: { claudeDir?: boolean; claudeMd?: boolean } = {}): string {
+    const dir = mkdtempSync(join(tmpdir(), 'lodestar-ss-'))
+    ssTmpDirs.push(dir)
+    if (entries.claudeDir) mkdirSync(join(dir, '.claude'))
+    if (entries.claudeMd) writeFileSync(join(dir, 'CLAUDE.md'), '# proj\n')
+    return dir
+  }
+  afterAll(() => {
+    for (const d of ssTmpDirs) rmSync(d, { recursive: true, force: true })
+  })
+
   test('settingSourcesFromProfile falls back to user when absent', () => {
     expect(settingSourcesFromProfile(undefined)).toEqual(['user'])
     expect(settingSourcesFromProfile({})).toEqual(['user'])
@@ -838,6 +850,41 @@ describe('Claude project profile overrides', () => {
   test('settingSourcesFromProfile falls back when only blanks given', () => {
     expect(settingSourcesFromProfile({ settingSources: '' })).toEqual(['user'])
     expect(settingSourcesFromProfile({ settingSources: ' , ' })).toEqual(['user'])
+  })
+
+  test('settingSourcesFromProfile auto detects project .claude → three sources', () => {
+    const dir = tmpProjectDir({ claudeDir: true })
+    expect(settingSourcesFromProfile({ settingSources: 'auto' }, dir)).toEqual(['user', 'project', 'local'])
+  })
+
+  test('settingSourcesFromProfile auto detects CLAUDE.md → three sources', () => {
+    const dir = tmpProjectDir({ claudeMd: true })
+    expect(settingSourcesFromProfile({ settingSources: 'auto' }, dir)).toEqual(['user', 'project', 'local'])
+  })
+
+  test('settingSourcesFromProfile auto with no project config → user', () => {
+    const dir = tmpProjectDir()
+    expect(settingSourcesFromProfile({ settingSources: 'auto' }, dir)).toEqual(['user'])
+  })
+
+  test('settingSourcesFromProfile auto without workDir → user', () => {
+    expect(settingSourcesFromProfile({ settingSources: 'auto' })).toEqual(['user'])
+  })
+
+  test('settingSourcesFromProfile AUTO is case-insensitive', () => {
+    const dir = tmpProjectDir({ claudeDir: true })
+    expect(settingSourcesFromProfile({ settingSources: 'AUTO' }, dir)).toEqual(['user', 'project', 'local'])
+  })
+
+  test('settingSourcesFromProfile "auto,project" stays auto (never drops user)', () => {
+    const hit = tmpProjectDir({ claudeDir: true })
+    expect(settingSourcesFromProfile({ settingSources: 'auto,project' }, hit)).toEqual(['user', 'project', 'local'])
+    const miss = tmpProjectDir()
+    expect(settingSourcesFromProfile({ settingSources: 'auto,project' }, miss)).toEqual(['user'])
+  })
+
+  test('settingSourcesFromProfile drops unknown tokens via whitelist', () => {
+    expect(settingSourcesFromProfile({ settingSources: 'user,bogus' })).toEqual(['user'])
   })
 
   test('toolsFromProfile falls back to claude_code preset when absent', () => {

--- a/src/claude-agent-process.ts
+++ b/src/claude-agent-process.ts
@@ -460,12 +460,45 @@ export const CLAUDE_ALLOW_DANGEROUSLY_SKIP_PERMISSIONS = true
 /** Default setting sources when no project profile overrides them. */
 const DEFAULT_SETTING_SOURCES: readonly string[] = ['user']
 
+/** Valid SDK setting sources; anything else in an explicit list is dropped. */
+const VALID_SETTING_SOURCES = new Set(['user', 'project', 'local'])
+
 /** Resolve SDK `settingSources` from a project profile's comma-separated
- * string (e.g. `"project"`), falling back to `['user']`. */
-export function settingSourcesFromProfile(profile: ProjectProfile | undefined): string[] {
-  if (!profile?.settingSources) return [...DEFAULT_SETTING_SOURCES]
-  const list = profile.settingSources.split(',').map(s => s.trim()).filter(Boolean)
-  return list.length ? list : [...DEFAULT_SETTING_SOURCES]
+ * string. Falls back to `['user']`.
+ *
+ * Special value `auto` (exclusive — may appear in a list but ignores the rest):
+ * if `<workDir>/.claude` or `<workDir>/CLAUDE.md` exists, expand to
+ * `['user','project','local']` (parity with launching claude in that dir);
+ * otherwise `['user']`. Both branches keep `user`, so `auto` never triggers the
+ * project-only "dropped ~/.claude/settings.json → hang" trap.
+ *
+ * Explicit lists are whitelist-filtered to valid sources; unknown tokens are
+ * dropped (logged), never forwarded to the SDK. */
+export function settingSourcesFromProfile(
+  profile: ProjectProfile | undefined,
+  workDir?: string,
+): string[] {
+  const raw = profile?.settingSources
+  if (!raw) return [...DEFAULT_SETTING_SOURCES]
+  const tokens = raw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
+  if (tokens.length === 0) return [...DEFAULT_SETTING_SOURCES]
+
+  if (tokens.includes('auto')) {
+    const extra = tokens.filter(t => t !== 'auto')
+    if (extra.length) {
+      log(`claude-agent-process: setting_sources "auto" is exclusive — ignoring [${extra.join(',')}]`)
+    }
+    const hasProjectConfig = !!workDir
+      && (existsSync(join(workDir, '.claude')) || existsSync(join(workDir, 'CLAUDE.md')))
+    return hasProjectConfig ? ['user', 'project', 'local'] : ['user']
+  }
+
+  const valid = tokens.filter(t => VALID_SETTING_SOURCES.has(t))
+  const dropped = tokens.filter(t => !VALID_SETTING_SOURCES.has(t))
+  if (dropped.length) {
+    log(`claude-agent-process: setting_sources dropping unknown token(s) [${dropped.join(',')}]`)
+  }
+  return valid.length ? valid : [...DEFAULT_SETTING_SOURCES]
 }
 
 /** Resolve SDK `tools` from a project profile's comma-separated built-in
@@ -662,7 +695,7 @@ export class ClaudeAgentProcess extends EventEmitter {
     if (profile) {
       log(`claude-agent-process: project profile active — settingSources=${profile.settingSources ?? '-'} strictMcp=${profile.strictMcp ?? false} tools=${profile.tools ?? '-'} loadProjectMcp=${profile.loadProjectMcp ?? false} keepInstructions=${(profile.keepLodestarInstructions ?? true)}`)
     }
-    const settingSources = settingSourcesFromProfile(profile)
+    const settingSources = settingSourcesFromProfile(profile, this.opts.workDir)
     const toolsOption = toolsFromProfile(profile)
     const strictMcpConfig = profile?.strictMcp === true
     const mcpServers = profile?.loadProjectMcp ? readProjectMcpServers(this.opts.workDir) : undefined
@@ -673,7 +706,7 @@ export class ClaudeAgentProcess extends EventEmitter {
       // resolveClaudeExecutableConfig 在 [claude].bin 配错路径时同步抛出;
       // 必须在 try 内调用,确保错误走 error/exit 事件而非穿透到调用方。
       const executable = resolveClaudeExecutableConfig()
-      log(`claude-agent-process: spawn SDK query model=${model ?? 'default'} effort=${this.opts.effort} cwd=${this.opts.workDir} executable=${executable.description}`)
+      log(`claude-agent-process: spawn SDK query model=${model ?? 'default'} effort=${this.opts.effort} cwd=${this.opts.workDir} settingSources=${settingSources.join('+')} executable=${executable.description}`)
       this.query = query({
         prompt: this.input,
         options: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,10 @@ export interface ClaudeModelConfig {
 export interface ProjectProfile {
   /** Absolute working directory. Falls back to `PROJECTS_ROOT/<name>`. */
   cwd?: string
-  /** Comma-separated setting sources, e.g. `"project"` or `"user,project"`. */
+  /** Comma-separated setting sources, e.g. `"project"` or `"user,project"`.
+   * Special value `"auto"`: auto-detect `<cwd>/.claude` or `<cwd>/CLAUDE.md` →
+   * `['user','project','local']` if present, else `['user']`.
+   * See `settingSourcesFromProfile` in claude-agent-process.ts. */
   settingSources?: string
   /** Only use MCP servers loaded via `loadProjectMcp`; ignore user/global MCP. */
   strictMcp?: boolean
@@ -186,6 +189,7 @@ function loadConfig(): LodestarConfig {
         if (typeof value !== 'string' || value.length === 0) continue
         switch (rawKey.trim()) {
           case 'cwd': profile.cwd = value; break
+          // value stored raw; `"auto"` + whitelist validation live in settingSourcesFromProfile
           case 'setting_sources': profile.settingSources = value; break
           case 'strict_mcp': profile.strictMcp = value === 'true'; break
           case 'tools': profile.tools = value; break


### PR DESCRIPTION
## 摘要

给 `[projects.<群>].setting_sources` 增加一个 `auto` 智能档:当绑定项目的工作目录自带 `.claude/` 或 `CLAUDE.md` 时,自动加载 `settingSources: ['user','project','local']`(等价于在该目录直接启动 claude code —— 项目 `CLAUDE.md` / skills / agents / `settings.json`+hooks 全部生效);否则退回 `['user']`。

## 动机

现有 `setting_sources` 要么默认 `user`(项目自带的 `.claude/` 完全不加载),要么手写 `project` / `user,project,local`。想还原"在项目目录里跑 claude code"的效果,用户必须知道要写全三源,而且纯 `project` 会排除 `~/.claude/settings.json` 导致请求发不出去 → 卡死(见 README 里的既有警告)。`auto` 一词解决:探测到项目配置就给全三源,探测不到就安全退回 `user`。

## 行为

- **含-token 检测**(大小写不敏感):`"auto,project"` 仍走 auto 分支,多余 token 忽略并记日志,**不会**退化成非法 `['project']` 而丢掉 `user`(即不重现 project-only 卡死)。
- 两个 auto 分支都含 `user`,始终安全。
- 顺带修一个既有小问题:显式列表现在按白名单 `{user,project,local}` 过滤,未知 token 丢弃并记日志——此前会把非法 token 原样转发给 SDK。
- **未配置 / 现有显式 profile 行为完全不变**(6 条既有回归测试锁定)。
- 仅对 **Claude 引擎**有效(Codex 无论如何自动读 `AGENTS.md`)。

## 改动

- `src/claude-agent-process.ts`:`settingSourcesFromProfile(profile, workDir?)` 新增 `workDir` 参数 + `auto` 逻辑 + 白名单;唯一调用点传 `workDir`;spawn 日志打 `settingSources=`(便于排查)。
- `src/claude-agent-process.test.ts`:+7 单测(真实临时目录 fixtures + `afterAll` 清理)。
- `src/config.ts` / `README.md`:文档 + 命中后 hooks 每轮在 daemon 内运行的运维警告。

## 测试

- `bun test`:全套通过(新增 7 条,0 fail);`cli.ts` bundle 编译通过。

## 已知风险

项目 `.claude/agents/` 经 `settingSources:['project']` 加载,依赖 `@anthropic-ai/claude-agent-sdk` 二进制的行为(在 v0.3.181 上实测有效)。SKILLS / CLAUDE.md / settings 的 `settingSources` 语义有公开文档;agents 一项建议随 SDK 升级复验。

## 兼容性

纯增量:新增一个可选 `setting_sources` 取值 + 一个可选函数参数。不改任何现有默认或显式档位的行为。
