### PR TITLE
fix(session): claude rate_limit_event 不再污染 codex 用量缓存

### DIFF
--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -9,6 +9,7 @@ const { Session } = await import('./session')
 const cardkit = await import('./cardkit')
 const { fixedModelChoices, normalizeFixedModelSelection } = await import('./session-model')
 const { config } = await import('./config')
+const { peekUsage, updateUsageFromRateLimits } = await import('./usage')
 
 interface FetchCall {
   method: string
@@ -853,5 +854,41 @@ describe('Session SDK-initiated bg-task resume turns', () => {
 
     expect(session.orphanAssistantSegments).toEqual([])
     expect(session.orphanAssistantCurrent).toBe('')
+  })
+})
+
+describe('Session usage cache cross-backend isolation', () => {
+  test('claude 的 rate_limit_event payload 不得覆盖 codex 用量缓存', () => {
+    // 先用一条 codex 形状的 payload 播种缓存(模块级单例)。
+    const seeded = updateUsageFromRateLimits({
+      planType: 'plus',
+      primary: { usedPercent: 42, resetsAt: 1_700_000_000, windowDurationMins: 300 },
+    })
+    expect(seeded.state).toBe('ok')
+
+    const session = new Session('probe', 'chat_id') as any
+    const claudeProc = new FakeAgentProc('claude')
+    session.wireProc(claudeProc)
+    // claude 的 rate_limit_info 形状(无 planType/primary/secondary):
+    // truthy 但与 codex 完全不同,穿过共享 handler 会被包成空窗口 ok 快照。
+    claudeProc.emit('rate_limits_updated', { status: 'allowed', unified_status: 'allowed' })
+
+    // 缓存对象必须原封不动(恒等,而非结构相等)。
+    expect(peekUsage()).toBe(seeded)
+  })
+
+  test('codex 的 rate_limits_updated 照常更新用量缓存', () => {
+    const session = new Session('probe', 'chat_id') as any
+    const codexProc = new FakeAgentProc('codex')
+    session.wireProc(codexProc)
+    codexProc.emit('rate_limits_updated', {
+      planType: 'pro',
+      primary: { usedPercent: 7, resetsAt: 1_700_000_000, windowDurationMins: 300 },
+    })
+
+    const snap = peekUsage() as any
+    expect(snap?.state).toBe('ok')
+    expect(snap?.subscriptionType).toBe('pro')
+    expect(snap?.fiveHour?.percent).toBe(7)
   })
 })

--- a/src/session.ts
+++ b/src/session.ts
@@ -1839,7 +1839,10 @@ export class Session {
       this.handleContextCompacted(notice)
     })
     p.on('rate_limits_updated', (rateLimits: any) => {
-      updateUsageFromRateLimits(rateLimits)
+      // usage.ts 的缓存是 codex 专属(planType/primary/secondary 形状)。claude
+      // 的 rate_limit_info 形状不同但同样 truthy,写入会把 codex 快照覆盖成
+      // 全 null 的假 ok 数据 —— 只放行 codex 进程的事件。
+      if (p.provider === 'codex') updateUsageFromRateLimits(rateLimits)
     })
     p.on('thread_goal_updated', (goal: ThreadGoal) => {
       this.handleThreadGoalUpdated(goal)


### PR DESCRIPTION
## 问题

`wireProc` 里 claude / codex 两种 agent 进程**共用同一个** `rate_limits_updated` handler,直接调用 `updateUsageFromRateLimits(rateLimits)`。

而 `usage.ts` 的用量缓存是 **codex 专属形状**(`planType` / `primary` / `secondary`)。Claude 进程发来的 `rate_limit_info` 形状不同,但**同样是 truthy** —— `updateUsageFromRateLimits` 只挡 falsy,于是 claude 的事件会被包成「全 null 窗口」的假 `ok` 快照,**覆盖掉 codex 的模块级用量缓存**。

结果:切到 codex 后,`hi` 面板 / footer 读到的是被 claude 事件污染过的空数据。

## 修复

`session.ts` 里给这个 handler 加一行守卫,只放行 `provider === 'codex'` 的进程事件进 codex 缓存:

```ts
p.on('rate_limits_updated', (rateLimits: any) => {
  // usage.ts 的缓存是 codex 专属(planType/primary/secondary 形状)。claude
  // 的 rate_limit_info 形状不同但同样 truthy,写入会把 codex 快照覆盖成
  // 全 null 的假 ok 数据 —— 只放行 codex 进程的事件。
  if (p.provider === 'codex') updateUsageFromRateLimits(rateLimits)
})
```

## 测试

先写失败复现测试(恒等断言:claude 的 rate_limit 事件到来后,codex 缓存对象**不被替换**),修复后转绿。

```
bun test src/session.test.ts
# 31 pass / 0 fail
```
