### PR TITLE
feat(model): settingSources 加 auto 智能档 + 白名单过滤

### DIFF
--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -1,7 +1,7 @@
 import { homedir, tmpdir } from 'node:os'
-import { mkdtempSync, writeFileSync, unlinkSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, unlinkSync, rmSync } from 'node:fs'
 import { delimiter, join, win32 } from 'node:path'
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
 
 mock.module('./config', () => ({
   config: {
@@ -825,6 +825,18 @@ describe('Claude transcript context tokens', () => {
 })
 
 describe('Claude project profile overrides', () => {
+  const ssTmpDirs: string[] = []
+  function tmpProjectDir(entries: { claudeDir?: boolean; claudeMd?: boolean } = {}): string {
+    const dir = mkdtempSync(join(tmpdir(), 'lodestar-ss-'))
+    ssTmpDirs.push(dir)
+    if (entries.claudeDir) mkdirSync(join(dir, '.claude'))
+    if (entries.claudeMd) writeFileSync(join(dir, 'CLAUDE.md'), '# proj\n')
+    return dir
+  }
+  afterAll(() => {
+    for (const d of ssTmpDirs) rmSync(d, { recursive: true, force: true })
+  })
+
   test('settingSourcesFromProfile falls back to user when absent', () => {
     expect(settingSourcesFromProfile(undefined)).toEqual(['user'])
     expect(settingSourcesFromProfile({})).toEqual(['user'])
@@ -838,6 +850,41 @@ describe('Claude project profile overrides', () => {
   test('settingSourcesFromProfile falls back when only blanks given', () => {
     expect(settingSourcesFromProfile({ settingSources: '' })).toEqual(['user'])
     expect(settingSourcesFromProfile({ settingSources: ' , ' })).toEqual(['user'])
+  })
+
+  test('settingSourcesFromProfile auto detects project .claude → three sources', () => {
+    const dir = tmpProjectDir({ claudeDir: true })
+    expect(settingSourcesFromProfile({ settingSources: 'auto' }, dir)).toEqual(['user', 'project', 'local'])
+  })
+
+  test('settingSourcesFromProfile auto detects CLAUDE.md → three sources', () => {
+    const dir = tmpProjectDir({ claudeMd: true })
+    expect(settingSourcesFromProfile({ settingSources: 'auto' }, dir)).toEqual(['user', 'project', 'local'])
+  })
+
+  test('settingSourcesFromProfile auto with no project config → user', () => {
+    const dir = tmpProjectDir()
+    expect(settingSourcesFromProfile({ settingSources: 'auto' }, dir)).toEqual(['user'])
+  })
+
+  test('settingSourcesFromProfile auto without workDir → user', () => {
+    expect(settingSourcesFromProfile({ settingSources: 'auto' })).toEqual(['user'])
+  })
+
+  test('settingSourcesFromProfile AUTO is case-insensitive', () => {
+    const dir = tmpProjectDir({ claudeDir: true })
+    expect(settingSourcesFromProfile({ settingSources: 'AUTO' }, dir)).toEqual(['user', 'project', 'local'])
+  })
+
+  test('settingSourcesFromProfile "auto,project" stays auto (never drops user)', () => {
+    const hit = tmpProjectDir({ claudeDir: true })
+    expect(settingSourcesFromProfile({ settingSources: 'auto,project' }, hit)).toEqual(['user', 'project', 'local'])
+    const miss = tmpProjectDir()
+    expect(settingSourcesFromProfile({ settingSources: 'auto,project' }, miss)).toEqual(['user'])
+  })
+
+  test('settingSourcesFromProfile drops unknown tokens via whitelist', () => {
+    expect(settingSourcesFromProfile({ settingSources: 'user,bogus' })).toEqual(['user'])
   })
 
   test('toolsFromProfile falls back to claude_code preset when absent', () => {

--- a/src/claude-agent-process.ts
+++ b/src/claude-agent-process.ts
@@ -460,12 +460,45 @@ export const CLAUDE_ALLOW_DANGEROUSLY_SKIP_PERMISSIONS = true
 /** Default setting sources when no project profile overrides them. */
 const DEFAULT_SETTING_SOURCES: readonly string[] = ['user']
 
+/** Valid SDK setting sources; anything else in an explicit list is dropped. */
+const VALID_SETTING_SOURCES = new Set(['user', 'project', 'local'])
+
 /** Resolve SDK `settingSources` from a project profile's comma-separated
- * string (e.g. `"project"`), falling back to `['user']`. */
-export function settingSourcesFromProfile(profile: ProjectProfile | undefined): string[] {
-  if (!profile?.settingSources) return [...DEFAULT_SETTING_SOURCES]
-  const list = profile.settingSources.split(',').map(s => s.trim()).filter(Boolean)
-  return list.length ? list : [...DEFAULT_SETTING_SOURCES]
+ * string. Falls back to `['user']`.
+ *
+ * Special value `auto` (exclusive — may appear in a list but ignores the rest):
+ * if `<workDir>/.claude` or `<workDir>/CLAUDE.md` exists, expand to
+ * `['user','project','local']` (parity with launching claude in that dir);
+ * otherwise `['user']`. Both branches keep `user`, so `auto` never triggers the
+ * project-only "dropped ~/.claude/settings.json → hang" trap.
+ *
+ * Explicit lists are whitelist-filtered to valid sources; unknown tokens are
+ * dropped (logged), never forwarded to the SDK. */
+export function settingSourcesFromProfile(
+  profile: ProjectProfile | undefined,
+  workDir?: string,
+): string[] {
+  const raw = profile?.settingSources
+  if (!raw) return [...DEFAULT_SETTING_SOURCES]
+  const tokens = raw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
+  if (tokens.length === 0) return [...DEFAULT_SETTING_SOURCES]
+
+  if (tokens.includes('auto')) {
+    const extra = tokens.filter(t => t !== 'auto')
+    if (extra.length) {
+      log(`claude-agent-process: setting_sources "auto" is exclusive — ignoring [${extra.join(',')}]`)
+    }
+    const hasProjectConfig = !!workDir
+      && (existsSync(join(workDir, '.claude')) || existsSync(join(workDir, 'CLAUDE.md')))
+    return hasProjectConfig ? ['user', 'project', 'local'] : ['user']
+  }
+
+  const valid = tokens.filter(t => VALID_SETTING_SOURCES.has(t))
+  const dropped = tokens.filter(t => !VALID_SETTING_SOURCES.has(t))
+  if (dropped.length) {
+    log(`claude-agent-process: setting_sources dropping unknown token(s) [${dropped.join(',')}]`)
+  }
+  return valid.length ? valid : [...DEFAULT_SETTING_SOURCES]
 }
 
 /** Resolve SDK `tools` from a project profile's comma-separated built-in
@@ -662,7 +695,7 @@ export class ClaudeAgentProcess extends EventEmitter {
     if (profile) {
       log(`claude-agent-process: project profile active — settingSources=${profile.settingSources ?? '-'} strictMcp=${profile.strictMcp ?? false} tools=${profile.tools ?? '-'} loadProjectMcp=${profile.loadProjectMcp ?? false} keepInstructions=${(profile.keepLodestarInstructions ?? true)}`)
     }
-    const settingSources = settingSourcesFromProfile(profile)
+    const settingSources = settingSourcesFromProfile(profile, this.opts.workDir)
     const toolsOption = toolsFromProfile(profile)
     const strictMcpConfig = profile?.strictMcp === true
     const mcpServers = profile?.loadProjectMcp ? readProjectMcpServers(this.opts.workDir) : undefined


### PR DESCRIPTION
## 背景

上游已支持项目 profile 的 `setting_sources`(`config.ts` 解析成 `profile.settingSources` 字符串,`settingSourcesFromProfile` 再转成 SDK 的 `settingSources` 数组)。本 PR 在这个**既有函数**上加两项增强,均向后兼容。

## 1. 白名单过滤

显式列表里的 token 现在只放行 `user` / `project` / `local`,未知 token 直接丢弃(记日志),不再原样转发给 SDK —— 防止 `config.toml` 里的笔误/非法值穿透到 Claude Code SDK。

## 2. `auto` 智能档(独占值)

`setting_sources = "auto"` 时:

- `<workDir>/.claude` 或 `<workDir>/CLAUDE.md` 存在 → 展开为 `['user','project','local']`(等价于直接在该目录起 claude,项目配置生效);
- 否则回落 `['user']`。

两个分支都保留 `user`,所以 `auto` **永不**触发「settingSources 只留 project/local、丢掉 `~/.claude/settings.json` 导致会话卡死」的陷阱。`auto` 与其它 token 混写时独占(忽略其余,记日志)。

调用点顺带传入 `this.opts.workDir`(与相邻 `readProjectMcpServers(this.opts.workDir)` 写法一致),让 `auto` 能探测项目配置。

## 兼容性

`settingSourcesFromProfile(profile, workDir?)` 的 `workDir` 为**可选参数**,旧调用不传也照常回落 `['user']`;未配 `setting_sources` 的项目行为不变。

## 测试

```
bun test src/claude-agent-process.test.ts
# 43 pass / 0 fail
```

新增单测覆盖:`auto`(有/无项目配置两种)、白名单丢弃未知 token、`auto` 独占忽略其余 token。
