### PR TITLE
fix(claude-agent): 无 .mcp.json 时静默,不再每次 spawn 打 ENOENT 噪音

### DIFF
--- a/src/claude-agent-process.ts
+++ b/src/claude-agent-process.ts
@@ -484,15 +484,22 @@ export function toolsFromProfile(
 }
 
 /** Read `<workDir>/.mcp.json` and return its `mcpServers` map, or undefined
- * when missing / unreadable / malformed. No silent fallback — the failure
- * is logged so the project knows its MCP didn't load. */
+ * when missing / unreadable / malformed. Missing (ENOENT) is silent — it's
+ * the common case (most projects ship no .mcp.json, and loadProjectMcp
+ * defaults to true so every spawn probes once); other failures are logged
+ * so the project knows its MCP didn't load. */
 export function readProjectMcpServers(workDir: string): Record<string, unknown> | undefined {
   const mcpPath = join(workDir, '.mcp.json')
   let raw: string
   try {
     raw = readFileSync(mcpPath, 'utf8')
   } catch (e) {
-    log(`claude-agent-process: project .mcp.json not readable at ${mcpPath}: ${e}`)
+    // ENOENT (no .mcp.json) is the common case — most projects ship none, and
+    // loadProjectMcp defaults to true so every spawn probes once. Stay silent
+    // to avoid log noise; only warn when the file exists but can't be read.
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log(`claude-agent-process: project .mcp.json not readable at ${mcpPath}: ${e}`)
+    }
     return undefined
   }
   try {


### PR DESCRIPTION
Since `ef65ffd` flipped `loadProjectMcp` default to `true` (CLI parity — project `.mcp.json` auto-discovery), every claude spawn probes `<cwd>/.mcp.json` once. Most projects ship no such file, yet the catch block logs an ENOENT each time — polluting debug logs with a spurious error on **every spawn**.

**Fix:** ENOENT (file absent) is the normal case → return `undefined` silently. Failures where the file *exists* but can't be read or parsed are still logged, so projects still learn their MCP didn't load.

- One-line behavior change in `src/claude-agent-process.ts`; docstring updated to match.
- Existing `readProjectMcpServers` tests (missing / malformed / valid / no-mcpServers) all green.
