### PR TITLE
feat(codex): support config-driven API provider profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ requires_openai_auth = "true"
 
 配好后面板出现 `codex:<slug>` 档位。lodestar spawn 时用 `codex app-server -c model_provider="lodestar_<slug>" …` 注入一个前缀隔离的 provider,并把 `api_key` 注入 env —— **不改你全局 `~/.codex/config.toml`,也不覆盖你已有的 `[model_providers.*]`**。缺 `base_url` / `api_key` / `model` 的档位在面板可见但选择被拦截。API 档位跳过 `codex login` 的 ChatGPT 登录检查(用 key 鉴权)。
 
+`hi` 控制台里的额度也会按当前 Codex 档位分流:官方 ChatGPT 登录档继续显示 5h / 周窗口;第三方 `codex:<slug>` 档位如果配置了 `api_key`,会尝试按 CCSwitch 同类约定读取 `<base_url>/v1/usage` 的 `remaining` / `quota.remaining` / `balance` 作为渠道余额。没有余额接口或只走 `requires_openai_auth` 时,面板会明确显示“第三方渠道,官方 ChatGPT 额度不适用”,不会再误提示去 `codex login`。
+
 > 已知限制(Windows):macOS/Linux 下 codex 以离散 argv 直接 spawn(不过 shell),`-c` 的 TOML 字面量精确传入;但 Windows 为兼容 `.cmd`/`.bat` shim 走 `shell:true`,`-c model_providers.<slug>.base_url="…"` 里的引号可能被 cmd.exe 处理。Windows 用户如遇自定义 provider 不生效,可改用全局 `~/.codex/config.toml` 配置。
 
 ---

--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ lodestar-setup
 
 `删` 会先确认对应 worktree 群没有正在运行的 Codex session,再检查 worktree 没有未提交变更,然后解散群并删除 worktree 目录;分支保留,合并和分支清理由 agent 处理。
 
+### 🧩 Codex API 档位(自定义 provider)
+
+默认 `Codex · GPT-5.5` 档位继承用户全局 `~/.codex/config.toml`(`model_provider` 指向哪就走哪)。要在飞书 `model` 面板里按档位/按群切换 Codex 的第三方 OpenAI 兼容端点,在 `config.toml` 加 `[codex.models.<slug>]`:
+
+```toml
+# 第三方 OpenAI 兼容端点(自带 key)
+[codex.models.kimi]
+display_name = "Codex · Kimi"
+base_url     = "https://api.moonshot.cn/v1"
+wire_api     = "chat"          # chat | responses,默认 chat
+api_key      = "sk-..."
+model        = "kimi-k2"
+effort       = "high"          # none|minimal|low|medium|high|xhigh,默认回落 xhigh
+
+# 走 codex OpenAI auth 的端点(无需 api_key)
+[codex.models.wuhen]
+base_url     = "https://api.wuhen-ai.com"
+wire_api     = "responses"
+model        = "gpt-5.5"
+requires_openai_auth = "true"
+```
+
+配好后面板出现 `codex:<slug>` 档位。lodestar spawn 时用 `codex app-server -c model_provider="lodestar_<slug>" …` 注入一个前缀隔离的 provider,并把 `api_key` 注入 env —— **不改你全局 `~/.codex/config.toml`,也不覆盖你已有的 `[model_providers.*]`**。缺 `base_url` / `api_key` / `model` 的档位在面板可见但选择被拦截。API 档位跳过 `codex login` 的 ChatGPT 登录检查(用 key 鉴权)。
+
+> 已知限制(Windows):macOS/Linux 下 codex 以离散 argv 直接 spawn(不过 shell),`-c` 的 TOML 字面量精确传入;但 Windows 为兼容 `.cmd`/`.bat` shim 走 `shell:true`,`-c model_providers.<slug>.base_url="…"` 里的引号可能被 cmd.exe 处理。Windows 用户如遇自定义 provider 不生效,可改用全局 `~/.codex/config.toml` 配置。
+
 ---
 
 ## 🎁 附加能力

--- a/docs/claude-agent-backend.md
+++ b/docs/claude-agent-backend.md
@@ -123,3 +123,7 @@ Claude 自带 ask 工具额外接了 SDK `onUserDialog`：
 - Claude SDK smoke: 临时目录中连续发送“只回复数字 1”和“只回复数字 2”，中途执行 `setModelSettings("claude:default", "low")` 成功；收到两次 `result subtype=success`，且两次 `session_id` 均为 `1e18c8b5-90f8-452f-a39a-e485e3ec4734`。
 - Claude ask smoke: `claude:glm` 启动时 SDK 日志显示 `model=opus`；实际触发 `AskUserQuestion`，自动回答后 assistant 输出 `DONE`，`result subtype=success` 且 `is_error=false`。
 - smoke 结束时本机 Claude 插件的 `SessionEnd` hook 在 stderr 报 `/bin/sh` ENOENT；`/bin/sh` 本机存在，turn 已成功完成。该警告来自外部 Claude 插件 hook，不属于 Lodestar ask/model 路径失败。
+
+## Codex API 档位（`[codex.models.*]`）
+
+Codex 侧的 per-slot API 路由,与 `[claude.models.*]` 同构(见 `src/codex-models.ts`)。每个 `[codex.models.<slug>]` 声明一个第三方 OpenAI 兼容端点(`base_url` / `wire_api` / `api_key` 或 `requires_openai_auth` / `model` / `effort`)。飞书面板出现 `codex:<slug>` 档位;`session.spawnAgent()` 经 `codexSpawnOverrides()` 把它解析为 `codex app-server -c model_provider="lodestar_<slug>" -c model_providers.lodestar_<slug>.*=…` 覆盖 + `LODESTAR_CODEX_<SLUG>_KEY` env 注入。`model_provider` 用 `lodestar_<slug>` 前缀隔离用户全局 `[model_providers.*]`;thread/start 的 `model` 是档位声明的真实模型 id(非 `codex:<slug>` 路由 key)。内建 `gpt-5.5` 是登录/默认档,不注入任何覆盖、继承用户全局 `~/.codex/config.toml`。未配置的 API 档位在 `onModelEffortSelect`/`normalizeFixedModelSelection` 被拦截/回落 `gpt-5.5`(复刻 GLM 守卫);API 档位在 `start()` 跳过 `isOpenAIChatGPTAuthenticated()` 预检。

--- a/src/cards/console.ts
+++ b/src/cards/console.ts
@@ -171,11 +171,20 @@ export function consoleUsageContent(
     case 'no_credentials':
       return '**📊 Codex 额度**　未登录 ChatGPT — 运行 `codex login`'
     case 'auth_failed':
-      return '**📊 Codex 额度**　当前不是 ChatGPT 登录 — 请运行 `codex login`'
+      return '**📊 Codex 额度**　非 ChatGPT 登录态 — 官方 ChatGPT 额度不适用'
     case 'rate_limited':
       return '**📊 Codex 额度**　API 429 限流,稍后重试'
     case 'network':
       return `**📊 Codex 额度**　拉取失败${usage.reason ? ' — `' + usage.reason + '`' : ''}`
+    case 'provider_usage': {
+      const valid = usage.isValid ? '' : ' · 渠道已停用'
+      return [
+        `**📊 Codex 额度** · ${usage.providerName}`,
+        `　· 渠道余额　${fmtProviderRemaining(usage.remaining, usage.unit)}${valid}`,
+      ].join('\n')
+    }
+    case 'provider_unavailable':
+      return `**📊 Codex 额度** · ${usage.providerName}　第三方渠道 — 官方 ChatGPT 额度不适用${usage.reason ? ' · ' + usage.reason : ''}`
   }
   const head = usage.subscriptionType
     ? `**📊 Codex 额度** · ChatGPT ${usage.subscriptionType}`
@@ -237,6 +246,13 @@ export function consoleGlmUsageContent(glmUsage: GlmUsageSnapshot | undefined): 
 
 function fmtUsagePercent(percent: number | null | undefined): string {
   return typeof percent === 'number' && Number.isFinite(percent) ? `${Math.round(percent)}%` : 'MISS'
+}
+
+function fmtProviderRemaining(remaining: number | string, unit: string): string {
+  const value = typeof remaining === 'number' && Number.isFinite(remaining)
+    ? String(Math.round(remaining * 100) / 100)
+    : String(remaining)
+  return unit ? `${value} ${unit}` : value
 }
 
 function fmtWindowLabel(mins: number | null | undefined, fallback: string): string {

--- a/src/cards/turn.test.ts
+++ b/src/cards/turn.test.ts
@@ -319,6 +319,29 @@ describe('main conversation card rendering', () => {
     expect(content).not.toContain('缓存')
     expect(content).not.toContain('~')
   })
+
+  test('usage panel does not ask for codex login when auth is non-ChatGPT', () => {
+    const content = consoleUsageContent({ state: 'auth_failed' })
+
+    expect(content).toContain('官方 ChatGPT 额度不适用')
+    expect(content).not.toContain('codex login')
+    expect(content).not.toContain('请运行')
+  })
+
+  test('usage panel renders third-party provider balance when available', () => {
+    const content = consoleUsageContent({
+      state: 'provider_usage',
+      providerName: 'Codex · Wuhen',
+      remaining: 12.34,
+      unit: 'USD',
+      isValid: true,
+      fetchedAt: Date.now(),
+    })
+
+    expect(content).toContain('Codex · Wuhen')
+    expect(content).toContain('渠道余额')
+    expect(content).toContain('12.34 USD')
+  })
 })
 
 describe('plan and goal rendering', () => {

--- a/src/claude-agent-process.test.ts
+++ b/src/claude-agent-process.test.ts
@@ -9,6 +9,10 @@ mock.module('./config', () => ({
       env: {},
       models: {},
     },
+    codex: {
+      env: {},
+      models: {},
+    },
   },
 }))
 

--- a/src/codex-models.test.ts
+++ b/src/codex-models.test.ts
@@ -17,6 +17,12 @@ mock.module('./config', () => ({
         broken: { base_url: 'https://x.example.com', api_key: 'sk-x' },
         // 登录档(无 base_url)
         legacy: { model: 'gpt-5.5' },
+        // API 档但靠 codex 的 ChatGPT 登录态(无痕),不自带 key
+        wuhen: {
+          base_url: 'https://api.wuhen-ai.com',
+          requires_openai_auth: 'true',
+          model: 'gpt-5.5',
+        },
       },
     },
     claude: { env: {}, models: {} },
@@ -32,6 +38,7 @@ const {
   codexModelProfiles,
   codexModelProfile,
   codexModelIsApiRoute,
+  codexModelRequiresOpenaiAuth,
   codexModelConfigured,
   codexModelEffort,
   resolveCodexModelId,
@@ -141,7 +148,15 @@ describe('config-driven lookups', () => {
   test('codexModelChoices lists only api slots (incl unconfigured)', () => {
     const choices = codexModelChoices()
     const models = choices.map(c => c.model).sort()
-    expect(models).toEqual(['codex:broken', 'codex:kimi'])
+    expect(models).toEqual(['codex:broken', 'codex:kimi', 'codex:wuhen'])
     expect(choices.find(c => c.model === 'codex:kimi')!.effort).toBe('high')
+  })
+  test('codexModelRequiresOpenaiAuth: only requires_openai_auth api slots keep the login precheck', () => {
+    // 无痕:API 档但仍需 ChatGPT 登录态 → 保留预检
+    expect(codexModelRequiresOpenaiAuth('codex:wuhen')).toBe(true)
+    // kimi:自带 key 的 API 档 → 跳过预检
+    expect(codexModelRequiresOpenaiAuth('codex:kimi')).toBe(false)
+    // 内建登录档(非 codex: 档位)→ 不适用
+    expect(codexModelRequiresOpenaiAuth('gpt-5.5')).toBe(false)
   })
 })

--- a/src/codex-models.test.ts
+++ b/src/codex-models.test.ts
@@ -56,9 +56,9 @@ describe('codex model slug helpers', () => {
 })
 
 describe('codexConfigArgs', () => {
-  test('builds -c overrides for provider + endpoint', () => {
+  test('builds -c overrides for provider + endpoint (api_key → env_key declared)', () => {
     const args = codexConfigArgs(
-      { base_url: 'https://api.moonshot.cn/v1', wire_api: 'chat', model: 'kimi-k2' },
+      { base_url: 'https://api.moonshot.cn/v1', wire_api: 'chat', api_key: 'sk-kimi', model: 'kimi-k2' },
       'kimi',
     )
     // flat ['-c','k=v', …];断言关键对存在
@@ -69,12 +69,14 @@ describe('codexConfigArgs', () => {
     // 每个 k=v 前面都跟一个 '-c'
     expect(args.filter(a => a === '-c').length).toBe((args.length) / 2)
   })
-  test('adds requires_openai_auth when set', () => {
+  test('adds requires_openai_auth and OMITS env_key when no api_key', () => {
     const args = codexConfigArgs(
       { base_url: 'https://api.wuhen-ai.com', requires_openai_auth: 'true', model: 'gpt-5.5' },
       'wuhen',
     )
     expect(args).toContain('model_providers.lodestar_wuhen.requires_openai_auth=true')
+    // codex 对未设的 env_key 变量会中止 → 无 api_key 时绝不声明 env_key(2026-07-06 实测)
+    expect(args.some(a => a.includes('.env_key='))).toBe(false)
   })
   test('defaults wire_api to chat', () => {
     const args = codexConfigArgs({ base_url: 'https://x' }, 'x')

--- a/src/codex-models.test.ts
+++ b/src/codex-models.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('./config', () => ({
+  config: {
+    codex: {
+      env: {},
+      models: {
+        kimi: {
+          display_name: 'Codex · Kimi',
+          base_url: 'https://api.moonshot.cn/v1',
+          wire_api: 'chat',
+          api_key: 'sk-kimi',
+          model: 'kimi-k2',
+          effort: 'high',
+        },
+        // 缺 model → 未配置
+        broken: { base_url: 'https://x.example.com', api_key: 'sk-x' },
+        // 登录档(无 base_url)
+        legacy: { model: 'gpt-5.5' },
+      },
+    },
+    claude: { env: {}, models: {} },
+  },
+}))
+
+const {
+  codexProviderSlug,
+  codexEnvKeyName,
+  codexEnvFromConfig,
+  codexConfigArgs,
+  toCodexProfile,
+  codexModelProfiles,
+  codexModelProfile,
+  codexModelIsApiRoute,
+  codexModelConfigured,
+  codexModelEffort,
+  resolveCodexModelId,
+  codexSpawnOverrides,
+  codexModelChoices,
+} = await import('./codex-models')
+
+describe('codex model slug helpers', () => {
+  test('provider slug is lodestar-prefixed and sanitized', () => {
+    expect(codexProviderSlug('wuhen-ai')).toBe('lodestar_wuhen_ai')
+  })
+  test('env key name is uppercase sanitized', () => {
+    expect(codexEnvKeyName('wuhen-ai')).toBe('LODESTAR_CODEX_WUHEN_AI_KEY')
+  })
+})
+
+describe('codexConfigArgs', () => {
+  test('builds -c overrides for provider + endpoint', () => {
+    const args = codexConfigArgs(
+      { base_url: 'https://api.moonshot.cn/v1', wire_api: 'chat', model: 'kimi-k2' },
+      'kimi',
+    )
+    // flat ['-c','k=v', …];断言关键对存在
+    expect(args).toContain('model_provider="lodestar_kimi"')
+    expect(args).toContain('model_providers.lodestar_kimi.base_url="https://api.moonshot.cn/v1"')
+    expect(args).toContain('model_providers.lodestar_kimi.wire_api="chat"')
+    expect(args).toContain('model_providers.lodestar_kimi.env_key="LODESTAR_CODEX_KIMI_KEY"')
+    // 每个 k=v 前面都跟一个 '-c'
+    expect(args.filter(a => a === '-c').length).toBe((args.length) / 2)
+  })
+  test('adds requires_openai_auth when set', () => {
+    const args = codexConfigArgs(
+      { base_url: 'https://api.wuhen-ai.com', requires_openai_auth: 'true', model: 'gpt-5.5' },
+      'wuhen',
+    )
+    expect(args).toContain('model_providers.lodestar_wuhen.requires_openai_auth=true')
+  })
+  test('defaults wire_api to chat', () => {
+    const args = codexConfigArgs({ base_url: 'https://x' }, 'x')
+    expect(args).toContain('model_providers.lodestar_x.wire_api="chat"')
+  })
+})
+
+describe('codexEnvFromConfig', () => {
+  test('injects api_key under generated env key', () => {
+    expect(codexEnvFromConfig({ api_key: 'sk-1' }, 'kimi')).toEqual({ LODESTAR_CODEX_KIMI_KEY: 'sk-1' })
+  })
+  test('empty when no api_key (requires_openai_auth path)', () => {
+    expect(codexEnvFromConfig({ requires_openai_auth: 'true' }, 'wuhen')).toEqual({})
+  })
+})
+
+describe('toCodexProfile', () => {
+  test('infers api route from base_url and computes configured', () => {
+    const p = toCodexProfile('kimi', {
+      base_url: 'https://api.moonshot.cn/v1', api_key: 'sk', model: 'kimi-k2',
+    })!
+    expect(p.key).toBe('codex:kimi')
+    expect(p.route).toBe('api')
+    expect(p.modelId).toBe('kimi-k2')
+    expect(p.configured).toBe(true)
+  })
+  test('api route missing model is not configured', () => {
+    const p = toCodexProfile('broken', { base_url: 'https://x', api_key: 'sk' })!
+    expect(p.route).toBe('api')
+    expect(p.configured).toBe(false)
+  })
+  test('login route (no base_url) is always configured with empty overrides', () => {
+    const p = toCodexProfile('legacy', { model: 'gpt-5.5' })!
+    expect(p.route).toBe('login')
+    expect(p.configured).toBe(true)
+    expect(p.configArgs).toEqual([])
+    expect(p.env).toEqual({})
+  })
+  test('explicit route wins over inference', () => {
+    const p = toCodexProfile('forced', { route: 'login', base_url: 'https://x' })!
+    expect(p.route).toBe('login')
+  })
+})
+
+describe('config-driven lookups', () => {
+  test('codexModelProfile resolves by codex: key', () => {
+    expect(codexModelProfile('codex:kimi')?.modelId).toBe('kimi-k2')
+    expect(codexModelProfile('gpt-5.5')).toBeNull()
+  })
+  test('codexModelIsApiRoute / codexModelConfigured', () => {
+    expect(codexModelIsApiRoute('codex:kimi')).toBe(true)
+    expect(codexModelConfigured('codex:kimi')).toBe(true)
+    expect(codexModelConfigured('codex:broken')).toBe(false)
+    expect(codexModelConfigured('gpt-5.5')).toBe(true) // 未知 key 当就绪
+  })
+  test('codexModelEffort reads per-slot effort', () => {
+    expect(codexModelEffort('codex:kimi')).toBe('high')
+  })
+  test('resolveCodexModelId maps codex: key to real id; bare id unchanged', () => {
+    expect(resolveCodexModelId('codex:kimi')).toBe('kimi-k2')
+    expect(resolveCodexModelId('gpt-5.5')).toBe('gpt-5.5')
+  })
+  test('codexSpawnOverrides: api slot carries args+env; login empty', () => {
+    const api = codexSpawnOverrides('codex:kimi')
+    expect(api.modelId).toBe('kimi-k2')
+    expect(api.env).toEqual({ LODESTAR_CODEX_KIMI_KEY: 'sk-kimi' })
+    expect(api.configArgs.length).toBeGreaterThan(0)
+    const login = codexSpawnOverrides('gpt-5.5')
+    expect(login).toEqual({ modelId: 'gpt-5.5', configArgs: [], env: {} })
+  })
+  test('codexModelChoices lists only api slots (incl unconfigured)', () => {
+    const choices = codexModelChoices()
+    const models = choices.map(c => c.model).sort()
+    expect(models).toEqual(['codex:broken', 'codex:kimi'])
+    expect(choices.find(c => c.model === 'codex:kimi')!.effort).toBe('high')
+  })
+})

--- a/src/codex-models.ts
+++ b/src/codex-models.ts
@@ -57,7 +57,6 @@ export function codexEnvFromConfig(raw: CodexModelConfig, slug: string): Record<
 export function codexConfigArgs(raw: CodexModelConfig, slug: string): string[] {
   const provider = codexProviderSlug(slug)
   const base = `model_providers.${provider}`
-  const envKey = raw.env_key?.trim() || codexEnvKeyName(slug)
   const args: string[] = [
     '-c', `model_provider="${provider}"`,
     '-c', `${base}.name="${sanitizeSlug(slug)}"`,
@@ -65,7 +64,12 @@ export function codexConfigArgs(raw: CodexModelConfig, slug: string): string[] {
   const baseUrl = raw.base_url?.trim()
   if (baseUrl) args.push('-c', `${base}.base_url="${baseUrl}"`)
   args.push('-c', `${base}.wire_api="${wireApiOf(raw)}"`)
-  args.push('-c', `${base}.env_key="${envKey}"`)
+  // env_key 只在真注入 api_key 时声明:codex 对"env_key 指向未设环境变量"会直接
+  // 报 `Missing environment variable` 并中止,故 requires_openai_auth(走 codex 的
+  // OpenAI 登录态、无独立 key)的档位绝不能声明 env_key。与 codexEnvFromConfig
+  // 的 api_key 门槛保持一致。(2026-07-06 实测:无痕 wuhen 带 env_key 必报错。)
+  const apiKey = raw.api_key?.trim()
+  if (apiKey) args.push('-c', `${base}.env_key="${raw.env_key?.trim() || codexEnvKeyName(slug)}"`)
   if (requiresOpenaiAuth(raw)) args.push('-c', `${base}.requires_openai_auth=true`)
   return args
 }

--- a/src/codex-models.ts
+++ b/src/codex-models.ts
@@ -1,0 +1,175 @@
+import { config, type CodexModelConfig } from './config'
+import { CODEX_EFFORT, isCodexReasoningEffort, type CodexReasoningEffort } from './codex-process'
+
+export interface CodexModelProfile {
+  key: string            // 'codex:<slug>'
+  name: string           // 原始 slug
+  displayName: string
+  description: string
+  /** 发给 app-server thread/start 的真实模型 id。 */
+  modelId: string
+  route: 'login' | 'api'
+  /** lodestar 注入的 provider id(model_provider 覆盖值);login 恒 ''。 */
+  providerSlug: string
+  /** spawn 注入的 env(装 key);login / 无 api_key 时为空。 */
+  env: Record<string, string>
+  /** spawn 追加的 `-c` 覆盖对(flat: '-c','k=v',…);login 恒 []。 */
+  configArgs: string[]
+  /** login 恒 true;api 需 base_url +(api_key 或 requires_openai_auth)+ model。 */
+  configured: boolean
+}
+
+const DEFAULT_WIRE_API = 'chat'
+
+/** slug 归一为合法的 provider id / env 片段:非 [A-Za-z0-9_] → '_'。 */
+function sanitizeSlug(slug: string): string {
+  return slug.trim().replace(/[^a-zA-Z0-9_]/g, '_').replace(/^_+|_+$/g, '') || 'slot'
+}
+
+/** lodestar 注入的 codex provider id,前缀隔离用户全局 [model_providers.*]。 */
+export function codexProviderSlug(slug: string): string {
+  return `lodestar_${sanitizeSlug(slug)}`
+}
+
+/** 装 api_key 的环境变量名。 */
+export function codexEnvKeyName(slug: string): string {
+  return `LODESTAR_CODEX_${sanitizeSlug(slug).toUpperCase()}_KEY`
+}
+
+function wireApiOf(raw: CodexModelConfig): string {
+  const w = raw.wire_api?.trim()
+  return w === 'responses' || w === 'chat' ? w : DEFAULT_WIRE_API
+}
+
+function requiresOpenaiAuth(raw: CodexModelConfig): boolean {
+  return raw.requires_openai_auth?.trim() === 'true'
+}
+
+/** api_key → { envKey: key };没配(靠 requires_openai_auth)→ {}。 */
+export function codexEnvFromConfig(raw: CodexModelConfig, slug: string): Record<string, string> {
+  const key = raw.api_key?.trim()
+  if (!key) return {}
+  const envKey = raw.env_key?.trim() || codexEnvKeyName(slug)
+  return { [envKey]: key }
+}
+
+/** 该档位追加的 `-c` 覆盖对(flat 数组:'-c','k=v','-c','k=v',…)。 */
+export function codexConfigArgs(raw: CodexModelConfig, slug: string): string[] {
+  const provider = codexProviderSlug(slug)
+  const base = `model_providers.${provider}`
+  const envKey = raw.env_key?.trim() || codexEnvKeyName(slug)
+  const args: string[] = [
+    '-c', `model_provider="${provider}"`,
+    '-c', `${base}.name="${sanitizeSlug(slug)}"`,
+  ]
+  const baseUrl = raw.base_url?.trim()
+  if (baseUrl) args.push('-c', `${base}.base_url="${baseUrl}"`)
+  args.push('-c', `${base}.wire_api="${wireApiOf(raw)}"`)
+  args.push('-c', `${base}.env_key="${envKey}"`)
+  if (requiresOpenaiAuth(raw)) args.push('-c', `${base}.requires_openai_auth=true`)
+  return args
+}
+
+function routeOf(raw: CodexModelConfig): 'login' | 'api' {
+  if (raw.route === 'api' || raw.route === 'login') return raw.route
+  return raw.base_url?.trim() ? 'api' : 'login'
+}
+
+export function toCodexProfile(slug: string, raw: CodexModelConfig): CodexModelProfile | null {
+  const name = slug.trim()
+  if (!name) return null
+  const route = routeOf(raw)
+  const modelId = raw.model?.trim() || ''
+  const env = route === 'api' ? codexEnvFromConfig(raw, slug) : {}
+  const configArgs = route === 'api' ? codexConfigArgs(raw, slug) : []
+  const configured =
+    route === 'login' ||
+    (!!raw.base_url?.trim() &&
+      (!!raw.api_key?.trim() || requiresOpenaiAuth(raw)) &&
+      !!modelId)
+  return {
+    key: `codex:${name}`,
+    name,
+    displayName: raw.display_name?.trim() || `Codex · ${name}`,
+    description: raw.description?.trim() || `使用 ${name} 路由运行 Codex 后端。`,
+    modelId,
+    route,
+    providerSlug: route === 'api' ? codexProviderSlug(slug) : '',
+    env,
+    configArgs,
+    configured,
+  }
+}
+
+export function codexModelProfiles(): CodexModelProfile[] {
+  return Object.entries(config.codex.models)
+    .map(([slug, raw]) => toCodexProfile(slug, raw))
+    .filter((p): p is CodexModelProfile => p !== null)
+}
+
+export function codexModelProfile(model: string | null | undefined): CodexModelProfile | null {
+  if (!model?.startsWith('codex:')) return null
+  const name = model.slice('codex:'.length)
+  if (!name) return null
+  return codexModelProfiles().find(p => p.name === name || p.key === model) ?? null
+}
+
+/** 该档位是否第三方 API 路由(true = spawn 时注入 provider + key)。 */
+export function codexModelIsApiRoute(model: string | null | undefined): boolean {
+  return codexModelProfile(model)?.route === 'api'
+}
+
+/** 该档位是否可用:登录/未知档恒 true;API 路由需 base_url + key + model 配好。 */
+export function codexModelConfigured(model: string | null | undefined): boolean {
+  const p = codexModelProfile(model)
+  return p ? p.configured : true
+}
+
+/** 该档位 config 声明的 effort(仅 API 路由);非法/未配 → undefined。 */
+export function codexModelEffort(model: string | null | undefined): CodexReasoningEffort | undefined {
+  const p = codexModelProfile(model)
+  if (!p || p.route !== 'api') return undefined
+  const raw = config.codex.models[p.name]?.effort?.trim()
+  return raw && isCodexReasoningEffort(raw) ? raw : undefined
+}
+
+/** codex:<slug> → 真实 modelId;非档位 key(裸 gpt-5.5)原样;未知 codex: → undefined。 */
+export function resolveCodexModelId(model: string | null | undefined): string | undefined {
+  const p = codexModelProfile(model)
+  if (p) return p.modelId || undefined
+  if (model?.startsWith('codex:')) return undefined
+  return model ?? undefined
+}
+
+/** spawn 时的 codex provider 覆盖。登录/未知档 → 空覆盖 + 原样 modelId,
+ * 绝不误伤现有 gpt-5.5。 */
+export function codexSpawnOverrides(model: string | null | undefined): {
+  modelId: string | undefined
+  configArgs: string[]
+  env: Record<string, string>
+} {
+  const p = codexModelProfile(model)
+  if (!p || p.route === 'login') {
+    return { modelId: resolveCodexModelId(model), configArgs: [], env: {} }
+  }
+  return { modelId: p.modelId || undefined, configArgs: p.configArgs, env: p.env }
+}
+
+/** picker 用:每个配好的 codex API 档位一个选项(含未配置的,选择时再拦截)。 */
+export function codexModelChoices(): Array<{
+  provider: 'codex'
+  model: string
+  displayName: string
+  description: string
+  effort: CodexReasoningEffort
+}> {
+  return codexModelProfiles()
+    .filter(p => p.route === 'api')
+    .map(p => ({
+      provider: 'codex' as const,
+      model: p.key,
+      displayName: p.displayName,
+      description: p.description,
+      effort: codexModelEffort(p.key) ?? CODEX_EFFORT,
+    }))
+}

--- a/src/codex-models.ts
+++ b/src/codex-models.ts
@@ -119,6 +119,15 @@ export function codexModelIsApiRoute(model: string | null | undefined): boolean 
   return codexModelProfile(model)?.route === 'api'
 }
 
+/** 该档位是否依赖 codex 的 OpenAI/ChatGPT 登录态(requires_openai_auth="true")。
+ * 这类 API 档位(如无痕 wuhen)不像自带 key 的档位,仍需 ChatGPT 登录,故 start()
+ * 的登录预检对它们保留。 */
+export function codexModelRequiresOpenaiAuth(model: string | null | undefined): boolean {
+  const p = codexModelProfile(model)
+  if (!p || p.route !== 'api') return false
+  return config.codex.models[p.name]?.requires_openai_auth?.trim() === 'true'
+}
+
 /** 该档位是否可用:登录/未知档恒 true;API 路由需 base_url + key + model 配好。 */
 export function codexModelConfigured(model: string | null | undefined): boolean {
   const p = codexModelProfile(model)

--- a/src/codex-process.test.ts
+++ b/src/codex-process.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 
 import {
   buildCodexAppServerArgs,
+  codexLoginStatusAuthenticated,
   diffUsageTotals,
   effectiveTurnTokens,
   contextCompactionNoticeFromMessage,
@@ -277,5 +278,18 @@ describe('buildCodexAppServerArgs', () => {
       '-c', 'model_provider="lodestar_kimi"',
       '--listen', 'stdio://',
     ])
+  })
+})
+
+describe('codexLoginStatusAuthenticated', () => {
+  test('ChatGPT OAuth login counts as authenticated', () => {
+    expect(codexLoginStatusAuthenticated('Logged in using ChatGPT')).toBe(true)
+  })
+  test('API key login counts as authenticated (无痕 wuhen 一类第三方 key)', () => {
+    expect(codexLoginStatusAuthenticated('Logged in using an API key - sk-69c70***37641')).toBe(true)
+  })
+  test('not-logged-in output is unauthenticated', () => {
+    expect(codexLoginStatusAuthenticated('Not logged in')).toBe(false)
+    expect(codexLoginStatusAuthenticated('')).toBe(false)
   })
 })

--- a/src/codex-process.test.ts
+++ b/src/codex-process.test.ts
@@ -283,14 +283,24 @@ describe('buildCodexAppServerArgs', () => {
 })
 
 describe('buildSpawnPath', () => {
-  test('prepends whitelist onto inherited PATH so homebrew/nvm node stays reachable', () => {
+  test('user-level bins stay ahead of inherited PATH (deterministic codex/tool resolution)', () => {
     // codex 常是 `#!/usr/bin/env node` 的 npm shim,node 可能只存在于继承 PATH 的某个目录
     // (如 Apple Silicon 的 /opt/homebrew/bin)。替换式 PATH 会丢掉它 → shim 退出 127。
     const path = buildSpawnPath('/opt/homebrew/bin:/usr/local/bin')
     expect(path).toContain('/opt/homebrew/bin')
-    // 白名单目录仍排在前,保持工具解析的确定性优先级
+    // 用户级 bin 仍排在继承 PATH 前,保持工具解析的确定性优先级
     expect(path.indexOf(join(homedir(), '.local', 'bin')))
       .toBeLessThan(path.indexOf('/opt/homebrew/bin'))
+  })
+
+  test('inherited node dirs win over the stale /usr/local/bin fallback (codex ESM needs modern node)', () => {
+    // 回归:/usr/local/bin 可能有陈旧 node(实测某机 v10.20.1)。codex 启动器是
+    // `#!/usr/bin/env node` 的 ESM,必须让继承 PATH 里的 homebrew/nvm 新 node 先命中,
+    // 否则老 node 解析 ESM 失败 → codex 退出 code=1。
+    const seg = buildSpawnPath('/opt/homebrew/bin').split(delimiter)
+    expect(seg.indexOf('/opt/homebrew/bin')).toBeLessThan(seg.lastIndexOf('/usr/local/bin'))
+    // 但系统兜底仍保留:整机唯一 node 只在 /usr/local/bin 时不至于退出 127
+    expect(seg).toContain('/usr/local/bin')
   })
 
   test('empty inherited PATH does not leave a stray/trailing delimiter', () => {

--- a/src/codex-process.test.ts
+++ b/src/codex-process.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { homedir, tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
 
 import {
   buildCodexAppServerArgs,
+  buildSpawnPath,
   codexLoginStatusAuthenticated,
   diffUsageTotals,
   effectiveTurnTokens,
@@ -278,6 +279,24 @@ describe('buildCodexAppServerArgs', () => {
       '-c', 'model_provider="lodestar_kimi"',
       '--listen', 'stdio://',
     ])
+  })
+})
+
+describe('buildSpawnPath', () => {
+  test('prepends whitelist onto inherited PATH so homebrew/nvm node stays reachable', () => {
+    // codex 常是 `#!/usr/bin/env node` 的 npm shim,node 可能只存在于继承 PATH 的某个目录
+    // (如 Apple Silicon 的 /opt/homebrew/bin)。替换式 PATH 会丢掉它 → shim 退出 127。
+    const path = buildSpawnPath('/opt/homebrew/bin:/usr/local/bin')
+    expect(path).toContain('/opt/homebrew/bin')
+    // 白名单目录仍排在前,保持工具解析的确定性优先级
+    expect(path.indexOf(join(homedir(), '.local', 'bin')))
+      .toBeLessThan(path.indexOf('/opt/homebrew/bin'))
+  })
+
+  test('empty inherited PATH does not leave a stray/trailing delimiter', () => {
+    const path = buildSpawnPath('')
+    expect(path).not.toContain(delimiter + delimiter)
+    expect(path.endsWith(delimiter)).toBe(false)
   })
 })
 

--- a/src/codex-process.test.ts
+++ b/src/codex-process.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
+  buildCodexAppServerArgs,
   diffUsageTotals,
   effectiveTurnTokens,
   contextCompactionNoticeFromMessage,
@@ -262,5 +263,19 @@ describe('codex token usage helpers', () => {
       cache_read_input_tokens: undefined,
     })
     expect(diffUsageTotals(null, null)).toBeNull()
+  })
+})
+
+describe('buildCodexAppServerArgs', () => {
+  test('no overrides → bare app-server on stdio', () => {
+    expect(buildCodexAppServerArgs([])).toEqual(['app-server', '--listen', 'stdio://'])
+  })
+  test('inserts -c overrides before --listen', () => {
+    const args = buildCodexAppServerArgs(['-c', 'model_provider="lodestar_kimi"'])
+    expect(args).toEqual([
+      'app-server',
+      '-c', 'model_provider="lodestar_kimi"',
+      '--listen', 'stdio://',
+    ])
   })
 })

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -67,23 +67,28 @@ function whichCodex(): string | null {
 }
 
 /**
- * spawn codex 子进程用的 PATH。
+ * spawn codex 子进程用的 PATH。分三段拼接,兼顾「确定性工具解析」与「用对 node 版本」:
+ *   1) 用户级 bin(npm-global/.local/.bun)—— prepend,保证 lodestar 自装的 codex/工具
+ *      优先命中,不受用户 shell PATH 影响。
+ *   2) 继承 PATH —— 紧随其后,让 homebrew/nvm 的现代 node 胜出。
+ *   3) 系统兜底(/usr/local/bin、/usr/bin、/bin)—— 放最后,仅当前两段都没有 node 时兜底,
+ *      避免整机唯一 node 只在 /usr/local/bin 时退出 127。
  *
- * 把确定性白名单 **prepend** 到继承的 PATH 之前,而不是整体替换。codex 在很多机器上是
- * homebrew / npm 全局装的 `#!/usr/bin/env node` shim,若把 PATH 整个替换成白名单,会丢掉
- * node 所在目录(典型如 Apple Silicon 的 /opt/homebrew/bin),shim 启动时 `env` 找不到
- * node,直接退出 127(2026-07-06 实测:任意 codex 档位首次 spawn 即撞,daemon 报
- * "Codex 异常退出 code=127")。白名单仍排在前以保持工具解析的确定性优先级。
+ * 为何系统目录不能再 prepend:codex 启动器是 `#!/usr/bin/env node` 的 ESM,`env node` 取
+ * PATH 首个命中。若 /usr/local/bin 排在继承 PATH 前面、而该目录存在陈旧 node(实测某机
+ * /usr/local/bin/node = v10.20.1),就会抢在 homebrew/nvm 的新 node 前被选中,ESM 解析
+ * 失败 → codex 退出 code=1(2026-07-07 实测无痕 wuhen 启动即撞)。此前只把系统目录 prepend,
+ * 修的是「白名单里没有 node → 退出 127」,修不了这种「老 node 抢占 → 退出 1」。
  */
 export function buildSpawnPath(inherited: string = process.env.PATH ?? ''): string {
   if (process.platform === 'win32') return inherited
-  const whitelist = [
+  const userBins = [
     join(homedir(), '.local', 'npm-global', 'bin'),
     join(homedir(), '.local', 'bin'),
     join(homedir(), '.bun', 'bin'),
-    '/usr/local/bin', '/usr/bin', '/bin',
   ]
-  return [...whitelist, inherited].filter(Boolean).join(delimiter)
+  const systemFallback = ['/usr/local/bin', '/usr/bin', '/bin']
+  return [...userBins, inherited, ...systemFallback].filter(Boolean).join(delimiter)
 }
 
 const CODEX_SESSIONS_DIR = join(homedir(), '.codex', 'sessions')

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -66,14 +66,24 @@ function whichCodex(): string | null {
   return null
 }
 
-function buildSpawnPath(): string {
-  if (process.platform === 'win32') return process.env.PATH ?? ''
-  return [
+/**
+ * spawn codex 子进程用的 PATH。
+ *
+ * 把确定性白名单 **prepend** 到继承的 PATH 之前,而不是整体替换。codex 在很多机器上是
+ * homebrew / npm 全局装的 `#!/usr/bin/env node` shim,若把 PATH 整个替换成白名单,会丢掉
+ * node 所在目录(典型如 Apple Silicon 的 /opt/homebrew/bin),shim 启动时 `env` 找不到
+ * node,直接退出 127(2026-07-06 实测:任意 codex 档位首次 spawn 即撞,daemon 报
+ * "Codex 异常退出 code=127")。白名单仍排在前以保持工具解析的确定性优先级。
+ */
+export function buildSpawnPath(inherited: string = process.env.PATH ?? ''): string {
+  if (process.platform === 'win32') return inherited
+  const whitelist = [
     join(homedir(), '.local', 'npm-global', 'bin'),
     join(homedir(), '.local', 'bin'),
     join(homedir(), '.bun', 'bin'),
     '/usr/local/bin', '/usr/bin', '/bin',
-  ].join(delimiter)
+  ]
+  return [...whitelist, inherited].filter(Boolean).join(delimiter)
 }
 
 const CODEX_SESSIONS_DIR = join(homedir(), '.codex', 'sessions')

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -42,6 +42,14 @@ export function resolveCodexBin(): string {
   return whichCodex() ?? 'codex'
 }
 
+/** `codex login status` 的输出是否表示已认证 —— ChatGPT OAuth 或 API key 皆可。
+ * codex 对 API key 登录输出 "Logged in using an API key - sk-…";ChatGPT 登录输出
+ * "Logged in using ChatGPT"。第三方档位(无痕 wuhen 一类)与全局也走 key 的内建
+ * gpt-5.5 档都用 API key,若只认 ChatGPT 会把它们误判为未登录而拦掉。 */
+export function codexLoginStatusAuthenticated(output: string): boolean {
+  return /Logged in using ChatGPT/i.test(output) || /Logged in using an API key/i.test(output)
+}
+
 function whichCodex(): string | null {
   const PATH = process.env.PATH ?? ''
   if (!PATH) return null

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -27,6 +27,11 @@ import {
 import { diffUsageTotals, effectiveTurnTokens, usageFromTokenUsagePayload } from './codex-usage'
 import type { AgentReasoningEffort } from './agent-process'
 
+/** 拼 `codex app-server` 命令行:把 provider 覆盖 `-c` 对插在 `--listen` 之前。 */
+export function buildCodexAppServerArgs(configArgs: string[] = []): string[] {
+  return ['app-server', ...configArgs, '--listen', 'stdio://']
+}
+
 export function resolveCodexBin(): string {
   if (process.platform !== 'win32') {
     const pinned = join(homedir(), '.local', 'npm-global', 'bin', 'codex')
@@ -72,6 +77,11 @@ export interface SpawnOpts {
   model?: string
   effort: CodexReasoningEffort
   appendSystemPrompt?: string
+  /** 追加到 `codex app-server` 命令行的 `-c` 覆盖对(flat:'-c','k=v',…),
+   * 由 codex API 档位注入自定义 provider。缺省 = 无覆盖(登录/默认档)。 */
+  configArgs?: string[]
+  /** 叠加进 spawn env 的 provider 接入变量(装 api_key)。缺省 = 无注入。 */
+  providerEnv?: Record<string, string>
 }
 
 export type CodexReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
@@ -256,7 +266,7 @@ export class CodexProcess extends EventEmitter {
     this.on('error', () => {})
     this.opts = opts
     const codexBin = resolveCodexBin()
-    const args = ['app-server', '--listen', 'stdio://']
+    const args = buildCodexAppServerArgs(opts.configArgs)
     log(`codex-process: spawn ${codexBin} app-server (cwd=${opts.workDir})`)
     this.proc = spawn(codexBin, args, {
       cwd: opts.workDir,
@@ -267,6 +277,7 @@ export class CodexProcess extends EventEmitter {
         NPM_CONFIG_LOGLEVEL: 'error',
         PATH: buildSpawnPath(),
         ...config.codex.env,
+        ...(opts.providerEnv ?? {}),
       },
     }) as ChildProcessByStdio<Writable, Readable, Readable>
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,9 @@ export interface LodestarConfig {
    * Empty record = no injection; Codex uses the user's ChatGPT login. */
   codex: {
     env: Record<string, string>
+    /** Per-slot 第三方 provider 档位,对应 `[codex.models.<slug>]`。空 record =
+     * 只有内建 gpt-5.5 登录/默认档。见 src/codex-models.ts。 */
+    models: Record<string, CodexModelConfig>
   }
   /** Env vars injected into the Claude Code subprocess used by
    * `@anthropic-ai/claude-agent-sdk`. Empty record = inherit the user's
@@ -57,6 +60,28 @@ export interface ClaudeModelConfig {
   display_name?: string
   description?: string
   model?: string
+}
+
+/** 第三方 Codex provider(OpenAI 兼容端点)接入配置,对应 `[codex.models.<slug>]`。
+ * 配了 base_url 即视为 API 路由:spawn 时用 `codex app-server -c` 覆盖注入一个
+ * `lodestar_<slug>` provider,并把 api_key 注入 env。都不配 = 登录档,继承用户
+ * 全局 `~/.codex/config.toml`。见 src/codex-models.ts。 */
+export interface CodexModelConfig {
+  display_name?: string
+  description?: string
+  model?: string
+  base_url?: string
+  /** `chat` | `responses`;缺省 `chat`。第三方 OpenAI 兼容端点多用 chat。 */
+  wire_api?: string
+  api_key?: string
+  /** 覆盖装 key 的环境变量名(缺省 lodestar 生成 LODESTAR_CODEX_<SLUG>_KEY)。 */
+  env_key?: string
+  /** 走 codex 的 OpenAI auth(如无痕 wuhen);置 "true" 时可不配 api_key。 */
+  requires_openai_auth?: string
+  /** 显式声明路由;缺省由是否配了 base_url 推断。 */
+  route?: 'login' | 'api'
+  /** 该档位锁定的思考强度(none|minimal|low|medium|high|xhigh);缺省回落 xhigh。 */
+  effort?: string
 }
 
 /** Per-project agent launch profile, sourced from `[projects.<name>].*`
@@ -172,6 +197,36 @@ function loadConfig(): LodestarConfig {
     }
     return out
   }
+  const codexModelSections = (): Record<string, CodexModelConfig> => {
+    const out: Record<string, CodexModelConfig> = {}
+    const prefix = 'codex.models.'
+    for (const [sectionName, section] of Object.entries(t)) {
+      if (!sectionName.startsWith(prefix)) continue
+      const key = sectionName.slice(prefix.length).trim()
+      if (!key) continue
+      const profile: CodexModelConfig = {}
+      for (const [rawKey, value] of Object.entries(section)) {
+        if (typeof value !== 'string' || value.length === 0) continue
+        const field = rawKey.trim()
+        if (
+          field === 'display_name' ||
+          field === 'description' ||
+          field === 'model' ||
+          field === 'base_url' ||
+          field === 'wire_api' ||
+          field === 'api_key' ||
+          field === 'env_key' ||
+          field === 'requires_openai_auth' ||
+          field === 'route' ||
+          field === 'effort'
+        ) {
+          ;(profile as Record<string, string>)[field] = value
+        }
+      }
+      out[key] = profile
+    }
+    return out
+  }
   // [projects.<name>] 节可选 —— 一个外部项目(如 evolving)想跑干净隔离的
   // Claude session:指定 cwd、限定内置工具、只挂自己的 .mcp.json。未配置的
   // 项目完全走 Lodestar 默认(settingSources:['user'] + claude_code 工具集)。
@@ -206,7 +261,7 @@ function loadConfig(): LodestarConfig {
     feishu: { app_id: appId, app_secret: appSecret },
     runtime: { projects_root: projectsRoot },
     notify: { bind: notifyBind, port: notifyPort },
-    codex: { env: codexEnv },
+    codex: { env: codexEnv, models: codexModelSections() },
     claude: { bin: claudeBin, env: claudeEnv, models: claudeModelSections() },
     projects: projectSections(),
   }

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -14,7 +14,7 @@ import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, extname, join } from 'node:path'
 import { config, type ProjectProfile } from './config'
-import { isCodexReasoningEffort, resolveCodexBin } from './codex-process'
+import { codexLoginStatusAuthenticated, isCodexReasoningEffort, resolveCodexBin } from './codex-process'
 import {
   isClaudeReasoningEffort,
   providerFromModel,
@@ -823,7 +823,7 @@ export function provisionProject(workDir: string): void {
 export function isOpenAIChatGPTAuthenticated(): boolean {
   try {
     const out = execSync(`"${resolveCodexBin()}" login status 2>&1`, { timeout: 10_000 }).toString()
-    return /Logged in using ChatGPT/i.test(out)
+    return codexLoginStatusAuthenticated(out)
   } catch { return false }
 }
 

--- a/src/session-model.ts
+++ b/src/session-model.ts
@@ -11,6 +11,12 @@ import {
 } from './agent-process'
 import * as cards from './cards'
 import * as feishu from './feishu'
+import {
+  codexModelChoices,
+  codexModelConfigured,
+  codexModelEffort,
+  codexModelIsApiRoute,
+} from './codex-models'
 import { log } from './log'
 import { messageOf, withTimeout, type ModelActionResult } from './session-util'
 
@@ -39,24 +45,59 @@ const FIXED_MODEL_CHOICES = [
   },
 ]
 
-function fixedModelChoices(s: Session): cards.ModelChoice[] {
+function defaultFixedChoiceFor(provider: AgentProvider): typeof FIXED_MODEL_CHOICES[number] {
+  return FIXED_MODEL_CHOICES.find(c => c.provider === provider) ?? FIXED_MODEL_CHOICES[0]
+}
+
+function resolvedEffort(item: typeof FIXED_MODEL_CHOICES[number]): AgentReasoningEffort {
+  if (item.provider === 'codex') {
+    const configured = codexModelEffort(item.model)
+    if (configured) return configured
+  }
+  return item.effort
+}
+
+export function normalizeFixedModelSelection(
+  provider: AgentProvider,
+  model: string | null | undefined,
+  _effort: AgentReasoningEffort | null | undefined,
+): { model: string; effort: AgentReasoningEffort } {
+  const all = [...FIXED_MODEL_CHOICES, ...codexModelChoices()]
+  const hit = all.find(c => c.provider === provider && c.model === model)
+  if (hit && provider === 'codex' && codexModelIsApiRoute(model) && !codexModelConfigured(model)) {
+    const fallback = defaultFixedChoiceFor(provider)
+    return { model: fallback.model, effort: resolvedEffort(fallback) }
+  }
+  const choice = hit ?? defaultFixedChoiceFor(provider)
+  return { model: choice.model, effort: resolvedEffort(choice) }
+}
+
+function choiceDescription(item: typeof FIXED_MODEL_CHOICES[number]): string {
+  if (item.provider === 'codex' && codexModelIsApiRoute(item.model) && !codexModelConfigured(item.model)) {
+    return `${item.description}(未配置 · 需在 config.toml 的 [codex.models.<slug>] 填 base_url + api_key(或 requires_openai_auth)+ model)`
+  }
+  return item.description
+}
+
+export function fixedModelChoices(s: Session): cards.ModelChoice[] {
   const currentProvider = s.currentProvider()
   const currentModel = s.currentModelLabel()
   const currentEffort = s.currentEffortLabel()
-  return FIXED_MODEL_CHOICES.map(item => {
+  return [...FIXED_MODEL_CHOICES, ...codexModelChoices()].map(item => {
     const selected = currentProvider === item.provider && currentModel === item.model
+    const effort = resolvedEffort(item)
     return {
       provider: item.provider,
       model: item.model,
       displayName: item.displayName,
-      description: item.description,
+      description: choiceDescription(item),
       isDefault: false,
       selected,
       efforts: [{
-        effort: item.effort,
+        effort,
         description: '',
         isDefault: true,
-        selected: selected && currentEffort === item.effort,
+        selected: selected && currentEffort === effort,
       }],
     }
   })
@@ -143,9 +184,16 @@ export async function onModelEffortSelect(
   const effort = effortValue as AgentReasoningEffort
   // 二元锁死:只放行 FIXED_MODEL_CHOICES 的 (provider, model, effort) 组合,
   // 拒绝旧 effort 回调/伪造把 session 切到非固定项或非锁死 effort。
-  const fixed = FIXED_MODEL_CHOICES.find(c => c.provider === provider && c.model === model)
-  if (!fixed || fixed.effort !== effort) {
+  const fixed = [...FIXED_MODEL_CHOICES, ...codexModelChoices()]
+    .find(c => c.provider === provider && c.model === model)
+  if (!fixed || resolvedEffort(fixed) !== effort) {
     return { ok: false, message: `${agentProviderLabel(provider)} · ${model}/${effort} 不在固定选项中` }
+  }
+  if (provider === 'codex' && codexModelIsApiRoute(model) && !codexModelConfigured(model)) {
+    return {
+      ok: false,
+      message: `Codex API 档位(${model})未配置:请在 ~/.config/lodestar/config.toml 的 [codex.models.<slug>] 填写 base_url、api_key(或 requires_openai_auth)和 model 后重试(内建 gpt-5.5 走全局 codex 配置,无需配置)`,
+    }
   }
   const choice = panel?.models.find(m => m.model === model && (m.provider ?? 'codex') === provider)
   if (choice && !choice.efforts.some(item => item.effort === effort)) {

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -11,6 +11,11 @@ const { fixedModelChoices, normalizeFixedModelSelection } = await import('./sess
 const { config } = await import('./config')
 const { peekUsage, updateUsageFromRateLimits } = await import('./usage')
 
+// Some test files mock ./config with only the fields they need. Keep this
+// file's Codex model tests isolated when the suite runs in one Bun process.
+;(config as any).codex ??= { env: {}, models: {} }
+;(config.codex as any).models ??= {}
+
 interface FetchCall {
   method: string
   path: string
@@ -335,6 +340,79 @@ describe('Session compact command', () => {
     expect(footerWrites.some(content =>
       content.includes('✅ 上下文已压缩') && content.includes('🧠 2% (5.4K/258K)')
     )).toBe(true)
+  })
+})
+
+describe('Codex API model choices', () => {
+  test('keeps configured codex api selections and uses configured effort', () => {
+    const prev = config.codex.models
+    ;(config.codex as any).models = {
+      kimi: {
+        base_url: 'https://api.moonshot.cn/v1',
+        api_key: 'sk',
+        model: 'kimi-k2',
+        effort: 'high',
+      },
+    }
+    try {
+      expect(normalizeFixedModelSelection('codex', 'codex:kimi', null))
+        .toEqual({ model: 'codex:kimi', effort: 'high' })
+    } finally {
+      ;(config.codex as any).models = prev
+    }
+  })
+
+  test('falls back to gpt-5.5 when a persisted codex api selection is incomplete', () => {
+    const prev = config.codex.models
+    ;(config.codex as any).models = {
+      broken: { base_url: 'https://x.example.com', api_key: 'sk' },
+    }
+    try {
+      expect(normalizeFixedModelSelection('codex', 'codex:broken', null))
+        .toEqual({ model: 'gpt-5.5', effort: 'xhigh' })
+    } finally {
+      ;(config.codex as any).models = prev
+    }
+  })
+
+  test('renders configured codex api profiles in the model panel', () => {
+    const prev = config.codex.models
+    ;(config.codex as any).models = {
+      kimi: {
+        display_name: 'Codex · Kimi',
+        description: 'Kimi API route.',
+        base_url: 'https://api.moonshot.cn/v1',
+        api_key: 'sk',
+        model: 'kimi-k2',
+        effort: 'high',
+      },
+    }
+    try {
+      const session = new Session('probe', 'chat_id') as any
+      const choices = fixedModelChoices(session)
+      const kimi = choices.find((choice: any) => choice.model === 'codex:kimi')
+      expect(kimi?.displayName).toBe('Codex · Kimi')
+      expect(kimi?.description).toBe('Kimi API route.')
+      expect(kimi?.efforts.map((e: any) => e.effort)).toEqual(['high'])
+    } finally {
+      ;(config.codex as any).models = prev
+    }
+  })
+
+  test('rejects incomplete codex api profiles during model selection', async () => {
+    const prev = config.codex.models
+    ;(config.codex as any).models = {
+      broken: { base_url: 'https://x.example.com', api_key: 'sk' },
+    }
+    try {
+      const session = new Session('probe', 'chat_id') as any
+      const result = await session.onModelEffortSelect('codex:broken', 'xhigh', '', 'ou_user', 'codex')
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('未配置')
+      expect(result.message).toContain('[codex.models.<slug>]')
+    } finally {
+      ;(config.codex as any).models = prev
+    }
   })
 })
 

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
   boundResumes, deletedReactions, projectProfiles, resetFeishuMock,
@@ -9,6 +10,7 @@ const { Session } = await import('./session')
 const cardkit = await import('./cardkit')
 const { fixedModelChoices, normalizeFixedModelSelection } = await import('./session-model')
 const { config } = await import('./config')
+const { PROJECTS_ROOT } = await import('./feishu')
 const { peekUsage, updateUsageFromRateLimits } = await import('./usage')
 
 // Some test files mock ./config with only the fields they need. Keep this
@@ -633,13 +635,13 @@ describe('Session workDir project profile override', () => {
 
   test('falls back to PROJECTS_ROOT/<name> without profile', () => {
     const session = new Session('plainproject', 'oc_test_plain')
-    expect(session.workDir).toBe('/tmp/lodestar-projects/plainproject')
+    expect(session.workDir).toBe(join(PROJECTS_ROOT, 'plainproject'))
   })
 
   test('ignores a blank cwd override', () => {
     projectProfiles.set('blankcwd', { cwd: '   ' })
     const session = new Session('blankcwd', 'oc_test_blank')
-    expect(session.workDir).toBe('/tmp/lodestar-projects/blankcwd')
+    expect(session.workDir).toBe(join(PROJECTS_ROOT, 'blankcwd'))
   })
 })
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -1194,7 +1194,7 @@ export class Session {
     if (this.currentProvider() === 'claude') {
       opts.glmUsage = await readGlmUsage()
     } else {
-      opts.usage = await readUsage()
+      opts.usage = await readUsage(this.currentModelLabel() ?? undefined)
     }
     await cardkit.replaceElement(cardId, cards.ELEMENTS.consoleUsage, cards.consoleUsageElement(opts))
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -31,6 +31,7 @@ import {
   type ThreadGoal,
   type TurnPlanUpdated,
 } from './codex-process'
+import { codexModelIsApiRoute, codexSpawnOverrides } from './codex-models'
 import {
   CLAUDE_EFFORT,
   agentProviderLabel,
@@ -385,17 +386,17 @@ export class Session {
     this.selectedProvider = selection?.provider ?? 'claude'
     this.selectedModel = selection?.model ?? null
     this.selectedEffort = selection?.effort ?? null
-    // model 命令已二元化:历史持久化的非固定值归一到固定两项,避免旧
-    // session-model-map 把 session 带到已下线的 profile(如 claude:deepseek)。
-    // 仅在有持久化选择时归一;无选择(默认)保持 null,交给 spawn 默认逻辑。
+    // model 命令已二元化:历史持久化的非固定值归一到固定项。Codex 还允许
+    // config.toml 的 [codex.models.*] 动态档位,所以归一化要经 session-model
+    // 统一判断,避免重启后把合法的 codex:<slug> 强制落回 gpt-5.5。
     if (selection) {
-      if (this.selectedProvider === 'claude' && this.selectedModel !== 'claude:glm') {
-        this.selectedModel = 'claude:glm'
-        this.selectedEffort = 'max'
-      } else if (this.selectedProvider === 'codex' && this.selectedModel !== 'gpt-5.5') {
-        this.selectedModel = 'gpt-5.5'
-        this.selectedEffort = 'xhigh'
-      }
+      const normalized = sessionModel.normalizeFixedModelSelection(
+        this.selectedProvider,
+        this.selectedModel,
+        this.selectedEffort,
+      )
+      this.selectedModel = normalized.model
+      this.selectedEffort = normalized.effort
     }
     if (this.selectedModel) {
       log(`session "${sessionName}": restored selected provider=${this.selectedProvider} model=${this.selectedModel} effort=${this.selectedEffort ?? 'unset'}`)
@@ -504,12 +505,15 @@ export class Session {
         profile: feishu.projectProfile(this.sessionName),
       })
     }
+    const overrides = codexSpawnOverrides(this.modelForSpawn())
     return new CodexProcess({
       workDir: this.workDir,
-      model: this.modelForSpawn(),
+      model: overrides.modelId,
       effort: this.effortForSpawn(),
       resumeSessionId,
       appendSystemPrompt: this.spawnDeveloperInstructions(),
+      configArgs: overrides.configArgs,
+      providerEnv: overrides.env,
     })
   }
 
@@ -692,7 +696,11 @@ export class Session {
     }
     if (this.selectedProvider === 'codex') report?.('🔎 检查 Codex 登录')
     else report?.('🔎 检查 Claude Code')
-    if (this.selectedProvider === 'codex' && !feishu.isOpenAIChatGPTAuthenticated()) {
+    if (
+      this.selectedProvider === 'codex' &&
+      !codexModelIsApiRoute(this.selectedModel) &&
+      !feishu.isOpenAIChatGPTAuthenticated()
+    ) {
       this.status = 'stopped'
       this.opts.onLifecycleChange?.()
       report?.('❌ Codex 未登录 ChatGPT 账号')

--- a/src/session.ts
+++ b/src/session.ts
@@ -703,9 +703,9 @@ export class Session {
     ) {
       this.status = 'stopped'
       this.opts.onLifecycleChange?.()
-      report?.('❌ Codex 未登录 ChatGPT 账号')
+      report?.('❌ Codex 未登录(ChatGPT 或 API key)')
       if (announce) {
-        await feishu.sendText(this.chatId, '❌ Codex 未登录 ChatGPT 账号。\n请在服务器上运行 `codex login` 后再试。')
+        await feishu.sendText(this.chatId, '❌ Codex 未登录(ChatGPT 或 API key 均可)。\n请在服务器上运行 `codex login`(或配好 API key)后再试。')
       }
       return false
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -31,7 +31,7 @@ import {
   type ThreadGoal,
   type TurnPlanUpdated,
 } from './codex-process'
-import { codexModelIsApiRoute, codexSpawnOverrides } from './codex-models'
+import { codexModelIsApiRoute, codexModelRequiresOpenaiAuth, codexSpawnOverrides } from './codex-models'
 import {
   CLAUDE_EFFORT,
   agentProviderLabel,
@@ -698,7 +698,7 @@ export class Session {
     else report?.('🔎 检查 Claude Code')
     if (
       this.selectedProvider === 'codex' &&
-      !codexModelIsApiRoute(this.selectedModel) &&
+      (!codexModelIsApiRoute(this.selectedModel) || codexModelRequiresOpenaiAuth(this.selectedModel)) &&
       !feishu.isOpenAIChatGPTAuthenticated()
     ) {
       this.status = 'stopped'

--- a/src/usage.test.ts
+++ b/src/usage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
-import { updateUsageFromRateLimits } from './usage'
+import { config } from './config'
+import { providerUsageSnapshotFromResponse, readUsage, updateUsageFromRateLimits } from './usage'
 
 describe('usage cache semantics', () => {
   test('keeps last live snapshot when a later live update payload is empty', () => {
@@ -30,5 +31,50 @@ describe('usage cache semantics', () => {
     if (snapshot.state !== 'ok') throw new Error('expected ok snapshot')
     expect(snapshot.fiveHour?.percent).toBeNull()
     expect(snapshot.weekly?.percent).toBeNull()
+  })
+})
+
+describe('provider usage snapshots', () => {
+  test('parses CCSwitch-compatible third-party provider balance payloads', () => {
+    const snapshot = providerUsageSnapshotFromResponse('Codex · Wuhen', {
+      quota: { remaining: 12.34, unit: 'USD' },
+      is_active: true,
+    })
+
+    expect(snapshot.state).toBe('provider_usage')
+    if (snapshot.state !== 'provider_usage') throw new Error('expected provider usage snapshot')
+    expect(snapshot.providerName).toBe('Codex · Wuhen')
+    expect(snapshot.remaining).toBe(12.34)
+    expect(snapshot.unit).toBe('USD')
+    expect(snapshot.isValid).toBe(true)
+  })
+
+  test('reports HTML provider usage responses as non-JSON instead of leaking parser errors', async () => {
+    const prevModels = config.codex.models
+    const prevFetch = globalThis.fetch
+    ;(config.codex as any).models = {
+      wuhen: {
+        display_name: 'Codex · 无痕',
+        base_url: 'https://api.wuhen-ai.com',
+        api_key: 'sk-test',
+        model: 'gpt-5.5',
+      },
+    }
+    globalThis.fetch = async () => new Response('<!doctype html><html></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    })
+
+    try {
+      const snapshot = await readUsage('codex:wuhen')
+
+      expect(snapshot.state).toBe('provider_unavailable')
+      if (snapshot.state !== 'provider_unavailable') throw new Error('expected provider_unavailable snapshot')
+      expect(snapshot.reason).toContain('非 JSON')
+      expect(snapshot.reason).not.toContain('Unexpected token')
+    } finally {
+      globalThis.fetch = prevFetch
+      ;(config.codex as any).models = prevModels
+    }
   })
 })

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -4,10 +4,17 @@
  * Source: Codex app-server `account/read` + `account/rateLimits/read`.
  * This stays on the same auth path as the daemon itself: the user's
  * local `codex login` ChatGPT session.
+ *
+ * Third-party Codex routes (`codex:<slug>`) do not expose the official
+ * ChatGPT rolling quota. For those routes we optionally query the
+ * provider `/v1/usage` endpoint using the CCSwitch-compatible balance
+ * response shape.
  */
 
 import { spawn, type ChildProcessByStdio } from 'node:child_process'
 import type { Readable, Writable } from 'node:stream'
+import { config } from './config'
+import { codexModelProfile } from './codex-models'
 import { resolveCodexBin } from './codex-process'
 import { log } from './log'
 
@@ -24,6 +31,19 @@ export type UsageSnapshot =
   | { state: 'auth_failed' }
   | { state: 'rate_limited' }
   | { state: 'network'; reason?: string }
+  | {
+      state: 'provider_usage'
+      providerName: string
+      remaining: number | string
+      unit: string
+      isValid: boolean
+      fetchedAt: number
+    }
+  | {
+      state: 'provider_unavailable'
+      providerName: string
+      reason?: string
+    }
   | {
       state: 'ok'
       subscriptionType?: string
@@ -112,6 +132,73 @@ function windowFromRateLimit(w: any): UsageWindow | null {
   }
 }
 
+function providerUsageEndpoint(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '')
+  const root = trimmed.replace(/\/v1$/i, '')
+  return `${root}/v1/usage`
+}
+
+function firstPresent(...values: unknown[]): unknown {
+  return values.find(v => v !== undefined && v !== null && v !== '')
+}
+
+function contentTypeIsJson(contentType: string | null): boolean {
+  return /\bjson\b/i.test(contentType ?? '')
+}
+
+function providerUsageSnapshotFromBody(providerName: string, body: string, contentType: string | null): UsageSnapshot {
+  const text = body.trim()
+  if (!text) {
+    return {
+      state: 'provider_unavailable',
+      providerName,
+      reason: '渠道余额接口返回空响应',
+    }
+  }
+
+  const looksJson = text.startsWith('{') || text.startsWith('[')
+  if (!looksJson && !contentTypeIsJson(contentType)) {
+    return {
+      state: 'provider_unavailable',
+      providerName,
+      reason: `渠道余额接口返回非 JSON${contentType ? ` (${contentType})` : ''}`,
+    }
+  }
+
+  try {
+    return providerUsageSnapshotFromResponse(providerName, JSON.parse(text))
+  } catch {
+    return {
+      state: 'provider_unavailable',
+      providerName,
+      reason: text.startsWith('<')
+        ? `渠道余额接口返回非 JSON${contentType ? ` (${contentType})` : ''}`
+        : '渠道余额接口 JSON 解析失败',
+    }
+  }
+}
+
+export function providerUsageSnapshotFromResponse(providerName: string, response: any): UsageSnapshot {
+  const remaining = firstPresent(response?.remaining, response?.quota?.remaining, response?.balance)
+  if (remaining === undefined) {
+    return {
+      state: 'provider_unavailable',
+      providerName,
+      reason: '余额接口未返回 remaining',
+    }
+  }
+  const unit = firstPresent(response?.unit, response?.quota?.unit, 'USD')
+  const isValid = firstPresent(response?.is_active, response?.isValid, true) !== false
+  return {
+    state: 'provider_usage',
+    providerName,
+    remaining: typeof remaining === 'number' ? remaining : String(remaining),
+    unit: String(unit),
+    isValid,
+    fetchedAt: Date.now(),
+  }
+}
+
 export function updateUsageFromRateLimits(rateLimits: any): UsageSnapshot {
   if (!rateLimits) return cache ?? { state: 'network', reason: 'empty rate limit update' }
   const snapshot: UsageSnapshotOk = {
@@ -123,6 +210,72 @@ export function updateUsageFromRateLimits(rateLimits: any): UsageSnapshot {
   }
   cache = snapshot
   return snapshot
+}
+
+async function fetchProviderUsage(model: string): Promise<UsageSnapshot | null> {
+  const profile = codexModelProfile(model)
+  if (!profile || profile.route !== 'api') return null
+  const providerName = profile.displayName || profile.name
+  const raw = config.codex.models[profile.name]
+  const baseUrl = raw?.base_url?.trim()
+  const apiKey = raw?.api_key?.trim()
+  if (!baseUrl) {
+    return {
+      state: 'provider_unavailable',
+      providerName,
+      reason: '未配置 base_url',
+    }
+  }
+  if (!apiKey) {
+    return {
+      state: 'provider_unavailable',
+      providerName,
+      reason: '未配置 api_key,无法查询渠道余额',
+    }
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+  try {
+    const res = await fetch(providerUsageEndpoint(baseUrl), {
+      method: 'GET',
+      headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' },
+      signal: controller.signal,
+    })
+    if (res.status === 429) return { state: 'rate_limited' }
+    if (res.status === 401 || res.status === 403) {
+      return {
+        state: 'provider_unavailable',
+        providerName,
+        reason: '渠道余额接口鉴权失败',
+      }
+    }
+    if (res.status === 404) {
+      return {
+        state: 'provider_unavailable',
+        providerName,
+        reason: '渠道未提供 /v1/usage',
+      }
+    }
+    if (!res.ok) {
+      return {
+        state: 'provider_unavailable',
+        providerName,
+        reason: `渠道余额接口 HTTP ${res.status}`,
+      }
+    }
+    return providerUsageSnapshotFromBody(providerName, await res.text(), res.headers.get('content-type'))
+  } catch (e: any) {
+    const reason = e?.name === 'AbortError' ? `timeout after ${API_TIMEOUT_MS}ms` : (e?.message ?? String(e))
+    log(`usage: provider usage fetch failed for ${providerName}: ${reason}`)
+    return {
+      state: 'provider_unavailable',
+      providerName,
+      reason,
+    }
+  } finally {
+    clearTimeout(timer)
+  }
 }
 
 async function fetchUsage(): Promise<UsageSnapshot> {
@@ -165,7 +318,12 @@ export function peekUsage(): UsageSnapshot | null {
   return cache
 }
 
-export async function readUsage(): Promise<UsageSnapshot> {
+export async function readUsage(model?: string): Promise<UsageSnapshot> {
+  if (model) {
+    const providerUsage = await fetchProviderUsage(model)
+    if (providerUsage) return providerUsage
+  }
+
   if (inFlight) return inFlight
 
   inFlight = fetchUsage()


### PR DESCRIPTION
## Summary
- Add `[codex.models.<slug>]` profile parsing and model-panel entries for custom OpenAI-compatible Codex providers.
- Inject per-profile `codex app-server -c` provider overrides and scoped API key environment variables without editing global Codex config.
- Tighten auth/config guards for API-key login, `requires_openai_auth`, missing `env_key`, and third-party usage balance display.

## Scope
- Keep upstream fixed model choices intact; this PR only adds config-driven Codex API provider profiles.

## Test Plan
- [x] `bun test`
- [x] `bun run build`