### PR TITLE
fix(session): rs 空闲列表分支改用 turn 语义,修复 stop 后不可达

### DIFF
--- a/src/session-commands.ts
+++ b/src/session-commands.ts
@@ -198,9 +198,12 @@ export async function runCommand(s: Session, raw: string, userOpenId = ''): Prom
       }
       return true
     case 'restart':
-      // rs 优化:会话进行中 = 打断 + 弃后台 + 恢复(走下面 restart(true),它已
-      // resetBackgroundTasks);空闲 = 列项目最近 24h 会话选恢复(比"只恢复上一会话"实用)。
-      if (!s.isRunning()) {
+      // rs 双模式:会话进行中 = 打断 + 弃后台 + 恢复(走下面 restart(true));空闲 =
+      // 列项目最近 24h 会话选恢复(比"只恢复上一会话"实用)。空闲判定用「无进行中
+      // turn」语义,与上面 stop 命令对齐 —— 不能用 !isRunning():isRunning() 判的是
+      // 进程存活,而 claude 进程 turn 间常驻保活(stop 故意 "Subprocess stays alive"),
+      // stop 后仍为 true,会让列表分支永远不可达(实测踩中,见 session.test.ts)。
+      if (!s.currentTurn && s.pendingUserMessageCount === 0 && s.pendingMidTurnMsgs.length === 0) {
         await s.showResumeList()
         return true
       }

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -963,3 +963,36 @@ describe('Session resetBackgroundTasks on kill/restart', () => {
     expect(session.openingBackground).toBe(false)
   })
 })
+
+describe('rs (restart) — 双模式列表分支', () => {
+  test('空闲态(proc 存活但无进行中 turn)应走 showResumeList,而非恢复上一会话', async () => {
+    const session = new Session('probe', 'chat_id') as any
+    // 复现 stop 后状态:进程保活(isRunning()=true)但无进行中 turn —— stop 注释明说
+    // "Subprocess stays alive",只 interrupt 不杀进程。这是用户实测踩中的场景。
+    session.proc = { isAlive: () => true, provider: 'claude' }
+    session.currentTurn = null
+    session.pendingUserMessageCount = 0
+    session.pendingMidTurnMsgs = []
+    session.selectedProvider = 'claude'
+    session.lastSessionId = 'aaaaaaaabbbbcccc'
+    session.runningAgy = false
+
+    let listCalled = false
+    let restartCalled = false
+    session.showResumeList = async () => { listCalled = true }
+    session.restart = async () => { restartCalled = true; return true }
+    // 恢复分支(修复前会走)依赖这些 —— stub 掉避免真发卡/报错,聚焦分支选择断言
+    session.openStatusCard = async () => null
+    session.closeStatusCard = async () => {}
+    session.withModel = (s: string) => s
+    session.withWorktreeInstructionNotice = (s: string) => s
+    session.backendLabel = () => 'claude'
+
+    await session.runCommand('rs')
+
+    // 修复前(!isRunning() 判定):isRunning=true → 走恢复分支 → listCalled=false、restartCalled=true → FAIL
+    // 修复后(无 turn 判定):走 showResumeList → listCalled=true、restartCalled=false → PASS
+    expect(listCalled).toBe(true)
+    expect(restartCalled).toBe(false)
+  })
+})


### PR DESCRIPTION
## 问题

`stop` 打断会话后再发 `rs`,预期走「列项目最近 24h 会话选恢复」的空闲分支,实际永远走「打断 + 恢复上一会话」分支——列表分支不可达。

## 根因

`rs` 的空闲判定用 `!s.isRunning()`,判的是**子进程存活**;而 claude 后端 turn 间进程常驻保活(`stop` 是软打断,注释原话 "Subprocess stays alive"),stop 后 `isRunning()` 仍为 `true`。

## 修复

空闲判定改用与上面 `stop` 命令一致的 turn 语义:

```ts
!s.currentTurn && s.pendingUserMessageCount === 0 && s.pendingMidTurnMsgs.length === 0
```

## 验证

- 补 failing→passing 测试(`session.test.ts`):复现 stop 后场景(proc 存活 `isRunning()=true` + 无 turn),断言走 `showResumeList` 而非 restart。
- `bun test src/session.test.ts`:35 pass / 0 fail。
- 全量 `bun test`:319 pass / 2 fail —— 与 upstream/main 基线相同的 2 个既有失败(跨文件 config 污染,单跑该文件全过),与本补丁无关。