### PR TITLE
fix(cards): sanitize 加固 —— 变长 fence 识别、图片 url 含空格、notify 保留 <font>

### DIFF
--- a/src/cards/elements.test.ts
+++ b/src/cards/elements.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { sanitizeMarkdownForCardKit } from './elements'
+import { sanitizeMarkdownForCardKit, downgradeExternalImagesForCardKit } from './elements'
 
 describe('sanitizeMarkdownForCardKit', () => {
   test('降级 prose 里的外链图片,保留 alt + url', () => {
@@ -55,5 +55,42 @@ describe('sanitizeMarkdownForCardKit', () => {
 
   test('空串安全', () => {
     expect(sanitizeMarkdownForCardKit('')).toBe('')
+  })
+
+  test('4+ 反引号 fence(fenceBlock 包裹含 ``` 的内容)内层 ``` 与 & < > 字面保留', () => {
+    // tool.ts 的 fenceBlock 在内容含 ``` 时把 fence 扩到 4+ 反引号;
+    // sanitize 必须用「同长反向引用」识别可变 fence,否则会把内层 ```
+    // 当边界劈开 fence,把 fence 内的 & < > 当 prose 转义。
+    const src = '````\nsee ```a < b & c``` here\n````'
+    expect(sanitizeMarkdownForCardKit(src)).toBe(src)
+  })
+
+  test('图片 url 含空格时保留完整(不截断到空白)', () => {
+    const out = sanitizeMarkdownForCardKit('![diagram](https://example.com/my architecture.png)')
+    expect(out).not.toMatch(/!\[/)
+    expect(out).toContain('https://example.com/my architecture.png')
+  })
+})
+
+describe('downgradeExternalImagesForCardKit', () => {
+  test('降级 prose 外链图片,代码块内图片原样保留', () => {
+    const out = downgradeExternalImagesForCardKit('图 ![](https://x/y.png) 代码\n```\n![](https://c/d.png)\n```')
+    expect(out).not.toMatch(/!\[\]\(https:\/\/x\//)
+    expect(out).toContain('https://x/y.png')
+    expect(out).toContain('![](https://c/d.png)')
+  })
+
+  test('保留 <font> 等 HTML 标签不转义(供 notify 调用方做彩色)', () => {
+    expect(downgradeExternalImagesForCardKit("<font color='red'>构建失败</font>"))
+      .toBe("<font color='red'>构建失败</font>")
+  })
+
+  test('prose 里的 & < > 不转义(与 sanitizeMarkdownForCardKit 的关键区别)', () => {
+    expect(downgradeExternalImagesForCardKit('a < b & c > d')).toBe('a < b & c > d')
+  })
+
+  test('代码块内的图片语法与 HTML 标签原样保留(字面)', () => {
+    const src = "```\n![](https://x/y.png)\n<font color='red'>x</font>\n```"
+    expect(downgradeExternalImagesForCardKit(src)).toBe(src)
   })
 })

--- a/src/cards/elements.ts
+++ b/src/cards/elements.ts
@@ -55,40 +55,58 @@ export const ELEMENTS = {
   tasklistPanel: 'tasklist_panel',
 } as const
 
-/**
- * 把不可信文本(用户消息 / LLM 正文 / 工具输出 / SDK 结构化字段)规范化成
- * Card Kit markdown 元素可安全渲染的 content。代码块 ``` 与行内 `code` 内是
- * 字面量,原样保留;只清洗其外的 prose:
- *  - 转义 & < >:Card Kit 会把这些当 HTML 结构吞掉。代码主动构造的飞书标签
- *    (<font> 等)不经此函数,不受影响。
- *  - 降级外链图片 ![alt](url):Card Kit 把它解析成 image 并拿 url 当
- *    img_key,而 img_key 必须是飞书素材库 key,外链 URL 会被服务端拒
- *    (ErrCode 200570 invalid image keys),导致整张卡 create / 元素 update
- *    失败。降级成纯文本标记,既不触发 image 解析,又保留原图地址。
- * 保留 **粗体** / [文字](url) / 列表 / 引用 / 代码块等合法 markdown。
- */
-export function sanitizeMarkdownForCardKit(text: string): string {
+/** 代码块感知遍历:fence(用「同长反向引用」识别可变长度,tool.ts 的
+ *  fenceBlock 会在内容含 ``` 时把 fence 扩到 4+ 反引号,固定 3 反引号正则会
+ *  把内层 ``` 误当边界劈开 fence)与行内 `code` 内是字面量,原样保留;只对
+ *  其外的 prose 跑 transform。 */
+function transformProseOutsideCode(text: string, transform: (prose: string) => string): string {
   if (!text) return text
-  const code = /```[\s\S]*?```|`[^`\n]*`/g
+  const code = /(`{3,})[\s\S]*?\1|`[^`\n]*`/g
   let out = ''
   let last = 0
   let m: RegExpExecArray | null
   while ((m = code.exec(text)) !== null) {
-    if (m.index > last) out += sanitizeProse(text.slice(last, m.index))
+    if (m.index > last) out += transform(text.slice(last, m.index))
     out += m[0]
     last = m.index + m[0].length
   }
-  if (last < text.length) out += sanitizeProse(text.slice(last))
+  if (last < text.length) out += transform(text.slice(last))
   return out
 }
 
-function sanitizeProse(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(
-      /!\[([^\]]*)\]\(([^)\s]+)[^)]*\)/g,
-      (_m, alt: string, url: string) => (alt.trim() ? `🖼️ ${alt.trim()} (${url})` : `🖼️ ${url}`),
-    )
+function escapeHtmlEntities(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** 降级 prose 里的外链图片 ![alt](url) 为纯文本标记。url 捕获到 `)` 前
+ *  (含空格也完整保留,trim 首尾空白)——Card Kit 把 ![alt](url) 解析成
+ *  image 并拿 url 当 img_key,外链 URL 会被服务端拒(ErrCode 200570),
+ *  导致整张卡 create / 元素 update 失败;降级既不触发 image 解析,又保留
+ *  原图地址。 */
+function downgradeExternalImagesInProse(s: string): string {
+  return s.replace(
+    /!\[([^\]]*)\]\(([^)]*)\)/g,
+    (_m, alt: string, url: string) => {
+      const u = url.trim()
+      return alt.trim() ? `🖼️ ${alt.trim()} (${u})` : `🖼️ ${u}`
+    },
+  )
+}
+
+/** 把不可信文本(用户消息 / LLM 正文 / 工具输出 / SDK 结构化字段)规范化成
+ *  Card Kit markdown 元素可安全渲染的 content:代码块与行内 code 字面保留,
+ *  只清洗其外 prose —— 转义 & < >(防被 CardKit 当 HTML 结构吞)+ 降级外链
+ *  图片。代码主动构造的飞书标签(<font> 等)经此函数会被转义;需保留标签做
+ *  彩色的场景(如 notify opts.text)用 downgradeExternalImagesForCardKit。
+ *  保留 **粗体** / [文字](url) / 列表 / 代码块等合法 markdown。 */
+export function sanitizeMarkdownForCardKit(text: string): string {
+  return transformProseOutsideCode(text, s => downgradeExternalImagesInProse(escapeHtmlEntities(s)))
+}
+
+/** 只降级外链图片、不转义 HTML —— 给 notify 这种调用方用:opts.text 里想用
+ *  <font color='...'> 做彩色强调(Card Kit 支持的合法标签,不执行脚本)。卡
+ *  失败的根因是外链图片(img_key 被拒),不是 HTML 标签,故只防图片、保留
+ *  <font> 等标签;代码块与行内 code 仍字面保留。 */
+export function downgradeExternalImagesForCardKit(text: string): string {
+  return transformProseOutsideCode(text, downgradeExternalImagesInProse)
 }

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -53,7 +53,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { randomUUID } from 'node:crypto'
 import { log } from './log'
 import * as feishu from './feishu'
-import { sanitizeMarkdownForCardKit } from './cards/elements'
+import { downgradeExternalImagesForCardKit, sanitizeMarkdownForCardKit } from './cards/elements'
 import {
   buildNotifyResult,
   get as getCallback,
@@ -148,7 +148,9 @@ export function buildNotifyCard(opts: {
       elements.push({ tag: 'markdown', content: `<font color='red'>📷 图片上传失败: ${img.src}</font>` })
     }
   }
-  elements.push({ tag: 'markdown', content: sanitizeMarkdownForCardKit(opts.text ?? '') || '_（空消息）_' })
+  // opts.text 用只降图片、不转义 HTML 的变体:notify 调用方会主动用 <font color='...'>
+  // 做彩色强调(上面图片上传失败行就是这么渲染的),全量转义会把它变成字面文本。
+  elements.push({ tag: 'markdown', content: downgradeExternalImagesForCardKit(opts.text ?? '') || '_（空消息）_' })
 
   if (opts.resolution) {
     // Post-click status marker replaces the button row. operator open_id


### PR DESCRIPTION
## 问题

f451779 修掉外链图片炸卡后,fork 侧实测又踩到三个边角:

1. **4+ 反引号 fence 被劈开**:`tool.ts` 的 `fenceBlock` 在内容本身含 ``` ``` ``` 时会把 fence 扩到 4+ 反引号,而 sanitize 的 fence 识别是固定 3 反引号正则——内层 ``` ``` ``` 被误当边界,fence 内的 `& < >` 被当 prose 转义,工具输出里的代码被改写。
2. **图片 url 含空格被截断**:url 捕获用 `[^)\s]+`,`![diagram](https://x/my architecture.png)` 降级后只剩 `https://x/my`,丢半截地址。
3. **notify 的 `<font>` 彩色被转义**:`opts.text` 走全量 sanitize,调用方主动写的 `<font color=…>`(Card Kit 支持的合法标签,notify 卡自己的「图片上传失败」行就在用)变成字面文本。

## 修复

- fence 识别改「同长反向引用」:`` /(`{3,})[\s\S]*?\1|`[^`\n]*`/ ``,可变长度 fence 整块字面保留。
- 图片 url 捕获到 `)` 前并 trim,含空格完整保留。
- 新增 `downgradeExternalImagesForCardKit`:只降级外链图片、不转义 HTML,给 notify `opts.text` 用——炸卡根因是外链 url 被当 img_key 拒(ErrCode 200570),不是 HTML 标签,故只防图片、保留 `<font>`;`r.reply` 维持全量 sanitize 不变。
- 内部重构:公共的「代码块感知遍历」提为 `transformProseOutsideCode`,两个出口共享 fence/inline-code 字面保留逻辑,行为语义对 `sanitizeMarkdownForCardKit` 既有调用方不变。

## 验证

- `elements.test.ts` 新增 6 个用例:4+ 反引号 fence 字面保留、url 含空格完整、downgrade 变体的图片降级/代码块保留/`<font>` 不转义/`& < >` 不转义。
- 全量 `bun test`:324 pass / 2 fail —— 仅 upstream/main 基线既有的 2 个失败(跨文件 config 污染,单跑对应文件全过),零回归。