### PR TITLE
feat(runtime): opt-in live_elapsed=second 按秒刷新 footer/后台卡

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ curl -sS -X POST http://127.0.0.1:9876/notify \
 
 配置在 `~/.config/lodestar/config.toml`,`lodestar-setup` 会帮你生成,手改也行。两个常被问的:
 
+### 想让 footer / 后台卡按秒刷新耗时?
+
+默认 `bucket`:活跃 footer 与后台任务 header 用相对档位(`<30s` / `<1m` / …),只在档位边界 push,省飞书 cardkit 配额。需要旧式按秒进度时:
+
+```toml
+[runtime]
+live_elapsed = "second"   # "bucket"(默认) | "second"
+```
+
+`second` 时 footer 约每 1s、后台卡约每 2s push,文案为 `45s` 这种整秒。改完需重启 daemon。
+
 ### 想让某个外部项目跑在别的目录?
 
 默认群名就是 `projects_root` 下的目录名。但如果你的项目放在别处、不想搬进来,在 config.toml 指一下它的目录就行——**section 名就是飞书群名**(daemon 用群名去 `config.projects[群名]` 取 cwd),其它项目不受影响:

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -131,4 +131,9 @@ export {
   backgroundLiveCard,
   backgroundHistoryCard,
   backgroundMigratedMarker,
+  elapsedBucket,
+  liveElapsed,
+  LIVE_ELAPSED_SECOND_FOOTER_TICK_MS,
+  LIVE_ELAPSED_SECOND_BACKGROUND_TICK_MS,
+  type LiveElapsedMode,
 } from './cards/background'

--- a/src/cards/AGENTS.md
+++ b/src/cards/AGENTS.md
@@ -17,7 +17,7 @@
 | `console.ts` | `hi` 控制台、状态卡、菜单卡、`model` 三级选择卡（`providerSelectionCard` 选账号 → `modelSelectionCard` 选模型 → `modelEffortSelectionCard` 选 effort → `modelResultCard` 结果，账号/模型列表由 `session-model.ts` 从 token sources 传入）、额度/主机信息格式化和关闭 streaming 设置。 |
 | `worktree.ts` | `wt` 列表卡和创建/加入提示卡，展示 `work/*` 分支状态、归档摘要并提供常驻删除按钮。 |
 | `task.ts` | `task` 清单面板卡，展示项目、清单名、绑定 GUID、分组状态、清单链接，以及启用/删除/确认删除按钮。 |
-| `background.ts` | SDK `task_*` 消息族(子 agent / 后台 bash / MCP / workflow)的状态累积 + 「后台游标卡」渲染:active/pending 双池(workflow/monitor 白名单 task_started 直入 active,其余前台 task 进 pending,对话推进时提升),吸附对话末尾,被新消息超越时沉降为历史快照,全终态固化留在原地。 |
+| `background.ts` | SDK `task_*` 消息族(子 agent / 后台 bash / MCP / workflow)的状态累积 + 「后台游标卡」渲染:active/pending 双池(workflow/monitor 白名单 task_started 直入 active,其余前台 task 进 pending,对话推进时提升),吸附对话末尾,被新消息超越时沉降为历史快照,全终态固化留在原地。含 `elapsedBucket` / `liveElapsed`(footer 与活跃 header 的 bucket/second 耗时模式)。 |
 | `temp.ts` | 临时会话 `fk`/`bk`/`rs` 卡片:`fk`/`bk` 的用户输入(turn 锚点)列表卡、`rs` 空闲模式的项目最近会话列表卡、`bk` 回滚后的 Write 记录卡;按钮 `value.kind`(`temp_fork_select`/`temp_back_select`/`temp_resume_select`)在 `daemon.ts` `handleCardAction` 里 dispatch。 |
 | `turn.test.ts` | Bun 测试，覆盖 turn card、模型选择、工具摘要、权限元素和 console/status card 的关键渲染。 |
 | `agy.test.ts` | Bun 测试，覆盖 agy 卡片结构、状态行、输出清理、仓库摘要和转发按钮。 |

--- a/src/cards/background.test.ts
+++ b/src/cards/background.test.ts
@@ -18,6 +18,9 @@ import {
   backgroundMigratedMarker,
   emptyBgStore,
   BG_ELEMENTS,
+  elapsedBucket,
+  liveElapsed,
+  LIVE_ELAPSED_SECOND_FOOTER_TICK_MS,
   type BgTaskEntry,
   type BgStore,
 } from './background'
@@ -28,6 +31,41 @@ const mk = (over: Partial<BgTaskEntry> & Pick<BgTaskEntry, 'id' | 'status'>): Bg
   startedAt: 0,
   steps: [],
   ...over,
+})
+
+describe('elapsedBucket', () => {
+  test('maps live elapsed time to stable labels and exact next boundaries', () => {
+    expect(elapsedBucket(-1)).toEqual({ label: '<30s', nextDelayMs: 30_000 })
+    expect(elapsedBucket(0)).toEqual({ label: '<30s', nextDelayMs: 30_000 })
+    expect(elapsedBucket(29_999)).toEqual({ label: '<30s', nextDelayMs: 1 })
+    expect(elapsedBucket(30_000)).toEqual({ label: '<1m', nextDelayMs: 30_000 })
+    expect(elapsedBucket(59_999)).toEqual({ label: '<1m', nextDelayMs: 1 })
+    expect(elapsedBucket(60_000)).toEqual({ label: '<3m', nextDelayMs: 120_000 })
+    expect(elapsedBucket(180_000)).toEqual({ label: '<5m', nextDelayMs: 120_000 })
+    expect(elapsedBucket(300_000)).toEqual({ label: '<10m', nextDelayMs: 300_000 })
+    expect(elapsedBucket(600_000)).toEqual({ label: '10m+', nextDelayMs: 600_000 })
+    expect(elapsedBucket(1_199_999)).toEqual({ label: '10m+', nextDelayMs: 1 })
+    expect(elapsedBucket(1_200_000)).toEqual({ label: '20m+', nextDelayMs: 600_000 })
+  })
+
+  test('normalizes non-finite input instead of producing a zero-delay timer loop', () => {
+    expect(elapsedBucket(Number.NaN)).toEqual({ label: '<30s', nextDelayMs: 30_000 })
+    expect(elapsedBucket(Number.POSITIVE_INFINITY)).toEqual({ label: '<30s', nextDelayMs: 30_000 })
+  })
+})
+
+describe('liveElapsed', () => {
+  test('bucket mode delegates to elapsedBucket', () => {
+    expect(liveElapsed(45_000, 'bucket')).toEqual(elapsedBucket(45_000))
+    expect(liveElapsed(45_000)).toEqual(elapsedBucket(45_000))
+  })
+
+  test('second mode returns whole-second labels and a 1s tick', () => {
+    expect(liveElapsed(0, 'second')).toEqual({ label: '0s', nextDelayMs: LIVE_ELAPSED_SECOND_FOOTER_TICK_MS })
+    expect(liveElapsed(999, 'second')).toEqual({ label: '0s', nextDelayMs: 1000 })
+    expect(liveElapsed(1_500, 'second')).toEqual({ label: '1s', nextDelayMs: 1000 })
+    expect(liveElapsed(45_000, 'second')).toEqual({ label: '45s', nextDelayMs: 1000 })
+  })
 })
 
 describe('applyBgTaskStarted — 白名单直入 active / 前台落 pending', () => {
@@ -311,6 +349,13 @@ describe('任务 panel —— 标题状态+时长,展开详情', () => {
     expect(panel.header.title.content).toContain('搜索认证')
     expect(panel.header.title.content).toContain('运行中')
     expect(panel.header.title.content).toContain('<1m')  // cc13607:45s 落 <1m 档
+  })
+
+  test('running + second 模式:header 写精确秒数', () => {
+    const t = mk({ id: 't1', type: 'subagent', description: '搜索认证', status: 'running', startedAt: 0, subagentType: 'Explore' })
+    const panel = backgroundTaskPanel(t, 45000, 'second') as any
+    expect(panel.header.title.content).toContain('(45s)')
+    expect(panel.header.title.content).not.toContain('<1m')
   })
 
   test('completed:header 写「用时 Ns」(用 usage.duration_ms)', () => {

--- a/src/cards/background.ts
+++ b/src/cards/background.ts
@@ -411,11 +411,21 @@ const FOOTER_BUCKETS = [
   { limit: 600_000, label: '<10m' },
 ]
 
+/** 活跃 footer / 后台卡 header 的耗时展示模式。
+ *  - `bucket`: 粗档位 (`<30s`/`<1m`/…)，只在档位边界 push（默认，省飞书配额）
+ *  - `second`: 旧行为，按秒显示并每秒/每 2s push */
+export type LiveElapsedMode = 'bucket' | 'second'
+
+/** second 模式下 footer 固定 1s tick；后台卡固定 2s（对齐旧 FOOTER_STATUS_TICK_MS /
+ *  BACKGROUND_REFRESH_TICK_MS，后台稍慢以少打一点 cardkit）。 */
+export const LIVE_ELAPSED_SECOND_FOOTER_TICK_MS = 1000
+export const LIVE_ELAPSED_SECOND_BACKGROUND_TICK_MS = 2000
+
 /** 相对时长档位:<30s / <1m / <3m / <5m / <10m,超过 10m 后每 10 分钟一档(10m+、20m+…)。
  *  返回当前档位标签 + 到下一档位边界的毫秒数。footer / 后台任务 header 用粗粒度档位
  *  代替秒数 —— 档位只在边界变,所以更新只发生在档位边界,不是每秒 tick。*/
 export function elapsedBucket(elapsedMs: number): { label: string; nextDelayMs: number } {
-  const ms = Math.max(0, elapsedMs)
+  const ms = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0
   for (const b of FOOTER_BUCKETS) {
     if (ms < b.limit) return { label: b.label, nextDelayMs: b.limit - ms }
   }
@@ -423,6 +433,25 @@ export function elapsedBucket(elapsedMs: number): { label: string; nextDelayMs: 
   const idx = Math.floor((ms - 600_000) / step)
   const nextBoundary = 600_000 + (idx + 1) * step
   return { label: `${(idx + 1) * 10}m+`, nextDelayMs: nextBoundary - ms }
+}
+
+/**
+ * Live elapsed for footer / background headers.
+ * `bucket` → coarse label + delay to next boundary;
+ * `second` → `Ns` label + fixed 1s delay (callers may override for background).
+ */
+export function liveElapsed(
+  elapsedMs: number,
+  mode: LiveElapsedMode = 'bucket',
+): { label: string; nextDelayMs: number } {
+  if (mode === 'second') {
+    const ms = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0
+    return {
+      label: `${Math.floor(ms / 1000)}s`,
+      nextDelayMs: LIVE_ELAPSED_SECOND_FOOTER_TICK_MS,
+    }
+  }
+  return elapsedBucket(elapsedMs)
 }
 
 function ownerOf(t: BgTaskEntry): string {
@@ -435,11 +464,18 @@ function terminalElapsed(t: BgTaskEntry): number {
   return 0
 }
 
-/** 标题里的状态+时长标签(折叠时常驻可见)。running 显示「已运行 Ns」,终态「用时/失败 Ns」。 */
-function statusLabel(t: BgTaskEntry, now: number): string {
+/** 标题里的状态+时长标签(折叠时常驻可见)。
+ *  活跃态按 liveElapsedMode 显示档位或秒数;终态保留精确耗时。 */
+function statusLabel(
+  t: BgTaskEntry,
+  now: number,
+  liveElapsedMode: LiveElapsedMode = 'bucket',
+): string {
+  const liveLabel = (elapsedMs: number): string =>
+    liveElapsed(elapsedMs, liveElapsedMode).label
   switch (t.status) {
-    case 'running': return `🟡 运行中 (${elapsedBucket(now - t.startedAt).label})`
-    case 'paused': return `⏸️ 已暂停 (${elapsedBucket(now - t.startedAt).label})`
+    case 'running': return `🟡 运行中 (${liveLabel(now - t.startedAt)})`
+    case 'paused': return `⏸️ 已暂停 (${liveLabel(now - t.startedAt)})`
     case 'pending': return `⚪ 等待中`
     case 'completed': return `✅ 用时 ${fmtElapsed(terminalElapsed(t))}`
     case 'failed': return `❌ 失败 ${fmtElapsed(terminalElapsed(t))}`
@@ -474,12 +510,17 @@ function renderDetailBody(t: BgTaskEntry): string {
 }
 
 /** 单任务的整 panel —— 标题写「图标 责任人·描述 — 状态·时长」,展开看详情 body。
- *  session 据此 addElement(新任务)/replaceElement(刷新,整个 panel)。 */
-export function backgroundTaskPanel(t: BgTaskEntry, now: number = Date.now()): object {
+ *  session 据此 addElement(新任务)/replaceElement(刷新,整个 panel)。
+ *  liveElapsedMode 只影响活跃态 header 时长文案;终态仍用精确 fmtElapsed。 */
+export function backgroundTaskPanel(
+  t: BgTaskEntry,
+  now: number = Date.now(),
+  liveElapsedMode: LiveElapsedMode = 'bucket',
+): object {
   return {
     tag: 'collapsible_panel',
     element_id: BG_ELEMENTS.panel(t.id),
-    header: { title: { tag: 'plain_text', content: `${TYPE_ICON[t.type]} ${ownerOf(t)} · ${t.description || '(无描述)'} — ${statusLabel(t, now)}` } },
+    header: { title: { tag: 'plain_text', content: `${TYPE_ICON[t.type]} ${ownerOf(t)} · ${t.description || '(无描述)'} — ${statusLabel(t, now, liveElapsedMode)}` } },
     expanded: false,
     elements: [{ tag: 'markdown', element_id: BG_ELEMENTS.body(t.id), content: renderDetailBody(t) }],
   }
@@ -487,7 +528,11 @@ export function backgroundTaskPanel(t: BgTaskEntry, now: number = Date.now()): o
 
 /** 活卡整张 JSON —— 首个后台任务到来时 sendCard 用。streaming 开。
  *  初始 body = 每任务一个 panel。 */
-export function backgroundLiveCard(tasks: BgTaskEntry[], now: number = Date.now()): object {
+export function backgroundLiveCard(
+  tasks: BgTaskEntry[],
+  now: number = Date.now(),
+  liveElapsedMode: LiveElapsedMode = 'bucket',
+): object {
   return {
     schema: '2.0',
     config: {
@@ -495,14 +540,18 @@ export function backgroundLiveCard(tasks: BgTaskEntry[], now: number = Date.now(
       summary: { content: backgroundLiveSummary(tasks) },
     },
     body: {
-      elements: tasks.map(t => backgroundTaskPanel(t, now)),
+      elements: tasks.map(t => backgroundTaskPanel(t, now, liveElapsedMode)),
     },
   }
 }
 
 /** 历史沉降卡 —— 用户发新消息且仍有活跃任务时,把旧卡 updateCard 成这个。
  *  只渲染终态任务,streaming 关。留在原地不再跟随。 */
-export function backgroundHistoryCard(tasks: BgTaskEntry[], now: number = Date.now()): object {
+export function backgroundHistoryCard(
+  tasks: BgTaskEntry[],
+  now: number = Date.now(),
+  liveElapsedMode: LiveElapsedMode = 'bucket',
+): object {
   const terminal = tasks.filter(isBgTerminal)
   return {
     schema: '2.0',
@@ -511,7 +560,7 @@ export function backgroundHistoryCard(tasks: BgTaskEntry[], now: number = Date.n
       summary: { content: `🧭 后台任务(历史) · ${terminal.length} 已结束` },
     },
     body: {
-      elements: terminal.map(t => backgroundTaskPanel(t, now)),
+      elements: terminal.map(t => backgroundTaskPanel(t, now, liveElapsedMode)),
     },
   }
 }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+interface FreshConfigResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+function loadFreshConfig(extraToml = ''): FreshConfigResult {
+  const root = mkdtempSync(join(tmpdir(), 'lodestar-config-fresh-'))
+  const configFile = join(root, 'config.toml')
+  const minimumConfig = [
+    '[feishu]',
+    'app_id = "cli_test"',
+    'app_secret = "secret"',
+  ].join('\n')
+  writeFileSync(configFile, `${minimumConfig}${extraToml ? `\n\n${extraToml.trim()}\n` : '\n'}`)
+
+  try {
+    const configModule = pathToFileURL(join(import.meta.dir, 'config.ts')).href
+    const script = [
+      `import { config } from ${JSON.stringify(configModule)}`,
+      'process.stdout.write(JSON.stringify(config))',
+    ].join('\n')
+    const result = Bun.spawnSync({
+      cmd: [process.execPath, '--eval', script],
+      env: { ...process.env, LODESTAR_CONFIG: configFile },
+    })
+
+    return {
+      exitCode: result.exitCode,
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+describe('runtime live_elapsed', () => {
+  test('defaults to bucket when omitted', () => {
+    const result = loadFreshConfig()
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(JSON.parse(result.stdout).runtime.live_elapsed).toBe('bucket')
+  })
+
+  test('accepts bucket and second values case-insensitively', () => {
+    const bucket = loadFreshConfig(`
+      [runtime]
+      live_elapsed = "Bucket"
+    `)
+    expect(bucket.exitCode).toBe(0)
+    expect(JSON.parse(bucket.stdout).runtime.live_elapsed).toBe('bucket')
+
+    const second = loadFreshConfig(`
+      [runtime]
+      live_elapsed = "SECOND"
+    `)
+    expect(second.exitCode).toBe(0)
+    expect(JSON.parse(second.stdout).runtime.live_elapsed).toBe('second')
+  })
+
+  test('rejects unknown live_elapsed values', () => {
+    const result = loadFreshConfig(`
+      [runtime]
+      live_elapsed = "realtime"
+    `)
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain('[runtime].live_elapsed')
+    expect(result.stderr).toContain('realtime')
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@
  *
  *   [runtime]
  *   projects_root = "~/"      # optional, defaults to $HOME
+ *   live_elapsed = "bucket"   # optional: "bucket"(default) | "second"
  *
  *   [notify]                  # all optional
  *   bind = "127.0.0.1"        # default 127.0.0.1 (loopback only)
@@ -21,6 +22,9 @@ import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { CONFIG_FILE } from './paths'
 
+/** 活跃 footer / 后台卡 header 耗时展示模式(config `[runtime].live_elapsed`)。 */
+export type LiveElapsedMode = 'bucket' | 'second'
+
 export interface LodestarConfig {
   feishu: {
     app_id: string
@@ -28,6 +32,12 @@ export interface LodestarConfig {
   }
   runtime: {
     projects_root: string
+    /**
+     * 活跃 footer / 后台卡 header 的耗时展示。
+     * - `bucket`(默认):粗档位,只在档位边界 push,省飞书配额
+     * - `second`:按秒显示,footer 每 1s / 后台卡每 2s push(旧行为,配额更费)
+     */
+    live_elapsed: LiveElapsedMode
   }
   notify: {
     bind: string
@@ -163,6 +173,13 @@ function loadConfig(): LodestarConfig {
     throw new Error(`lodestar: ${CONFIG_FILE} is missing [feishu].app_id / [feishu].app_secret`)
   }
   const projectsRoot = expandTilde(t.runtime?.projects_root ?? homedir())
+  const liveElapsedRaw = (t.runtime?.live_elapsed ?? 'bucket').trim().toLowerCase()
+  if (liveElapsedRaw !== 'bucket' && liveElapsedRaw !== 'second') {
+    throw new Error(
+      `lodestar: [runtime].live_elapsed must be "bucket" or "second", got "${t.runtime?.live_elapsed}"`,
+    )
+  }
+  const liveElapsed: LiveElapsedMode = liveElapsedRaw
   const notifyBind = t.notify?.bind ?? '127.0.0.1'
   const notifyPortRaw = t.notify?.port ?? '9876'
   const notifyPort = Number.parseInt(notifyPortRaw, 10)
@@ -258,7 +275,7 @@ function loadConfig(): LodestarConfig {
   const claudeBin = t.claude?.bin ? expandTilde(t.claude.bin) : undefined
   return {
     feishu: { app_id: appId, app_secret: appSecret },
-    runtime: { projects_root: projectsRoot },
+    runtime: { projects_root: projectsRoot, live_elapsed: liveElapsed },
     notify: { bind: notifyBind, port: notifyPort },
     codex: { env: codexEnv },
     claude: { bin: claudeBin, env: claudeEnv, models: claudeModelSections() },

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 import {
   boundResumes, deletedReactions, projectProfiles, resetFeishuMock,
   modelSelections, sentCards, sentRawTexts, sentTexts, urgentPushes,
@@ -7,9 +7,12 @@ import {
 
 const { Session } = await import('./session')
 const cardkit = await import('./cardkit')
+const { config } = await import('./config')
 const { resetTokenSourceRegistry } = await import('./token-source')
 const { buildTokenSourcesFromConfig } = await import('./token-source-builtins')
 const { peekUsage, updateUsageFromRateLimits } = await import('./usage')
+
+const DETERMINISTIC_FOOTER_HANDLE = 0xdeadbeef as unknown as ReturnType<typeof setTimeout>
 
 interface FetchCall {
   method: string
@@ -219,6 +222,11 @@ describe('Session token accounting', () => {
 
 describe('Session assistant rendering', () => {
   test('buffers assistant deltas and inserts one completed markdown element without content streaming', async () => {
+    // 本测断言 bucket 档位文案;本地 config 可能是 second,且全量 suite 里
+    // mock.module('./config') 可能缺 runtime —— 先补 runtime 再钉死 bucket。
+    const cfg = config as any
+    const previousRuntime = cfg.runtime
+    cfg.runtime = { ...(previousRuntime ?? {}), live_elapsed: 'bucket' }
     const session = new Session('probe', 'chat_id') as any
     const turn = turnState()
     session.currentTurn = turn
@@ -254,6 +262,8 @@ describe('Session assistant rendering', () => {
       expect(calls.some(call => call.path.endsWith('/content'))).toBe(false)
     } finally {
       session.stopFooterStatus(turn)
+      if (previousRuntime === undefined) delete cfg.runtime
+      else cfg.runtime = previousRuntime
       await cardkit.dispose(turn.cardId)
     }
   })
@@ -1069,5 +1079,67 @@ describe('Session resetBackgroundTasks on kill/restart', () => {
     expect(session.backgroundRefreshTimer).toBeNull() // timer 引用已清
     expect(session.backgroundDetailAdded.size).toBe(0)
     expect(session.openingBackground).toBe(false)
+  })
+})
+
+describe('Session live_elapsed second mode', () => {
+  test('second live_elapsed mode uses 1s footer and 2s background ticks', async () => {
+    // claude-agent-process.test 的 mock.module('./config') 会在全量 suite 里
+    // 把 config 换成缺 runtime 的 stub;这里先补上 runtime 再改 mode。
+    const cfg = config as any
+    const previousRuntime = cfg.runtime
+    cfg.runtime = { ...(previousRuntime ?? {}), live_elapsed: 'second' }
+    const session = new Session('second-scheduling', 'chat_id') as any
+    const turn = turnState('card_second_scheduling')
+    cardkit.recordCardCreated(turn.cardId, 1)
+    const delays: number[] = []
+    const timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation((
+      (_callback: (...args: any[]) => void, delay?: number) => {
+        delays.push(Number(delay ?? 0))
+        return DETERMINISTIC_FOOTER_HANDLE
+      }
+    ) as typeof setTimeout)
+
+    try {
+      session.startThinkingFooter(turn)
+      expect(delays).toHaveLength(1)
+      expect(delays[0]).toBe(1000)
+      session.stopFooterStatus(turn)
+
+      session.backgroundCard = { messageId: 'msg_second', cardId: 'card_second' }
+      session.backgroundTasks = [{
+        id: 'bg', type: 'shell', description: 'bg', status: 'running',
+        startedAt: Date.now() - 300_001, steps: [],
+      }]
+      session.startBackgroundRefreshTick()
+      expect(delays.at(-1)).toBe(2000)
+
+      // startFooterStatus 先 Date.now() 记 startedAt,再 Date.now() 算 elapsed。
+      // 第一次返回 base,后续返回 base+45s → 文案 Writing... (45s)。
+      session.stopFooterStatus(turn)
+      const base = Date.now()
+      let nowCalls = 0
+      const nowSpy = spyOn(Date, 'now').mockImplementation(() => {
+        nowCalls += 1
+        return nowCalls === 1 ? base : base + 45_000
+      })
+      try {
+        session.startWritingFooter(turn)
+      } finally {
+        nowSpy.mockRestore()
+      }
+      await cardkit.flush(turn.cardId)
+      const footerWrites = calls
+        .filter(call => call.method === 'PUT' && call.path === `/cards/${turn.cardId}/elements/footer`)
+        .map(call => JSON.parse(call.body.element).content as string)
+      expect(footerWrites.at(-1)).toContain('Writing... (45s)')
+    } finally {
+      session.stopFooterStatus(turn)
+      session.stopBackgroundRefreshTick()
+      timeoutSpy.mockRestore()
+      if (previousRuntime === undefined) delete cfg.runtime
+      else cfg.runtime = previousRuntime
+      await cardkit.dispose(turn.cardId)
+    }
   })
 })

--- a/src/session.ts
+++ b/src/session.ts
@@ -31,7 +31,11 @@ import {
   type ThreadGoal,
   type TurnPlanUpdated,
 } from './codex-process'
-import { elapsedBucket } from './cards/background'
+import {
+  liveElapsed,
+  LIVE_ELAPSED_SECOND_BACKGROUND_TICK_MS,
+  type LiveElapsedMode,
+} from './cards/background'
 import {
   CLAUDE_EFFORT,
   agentProviderLabel,
@@ -41,6 +45,7 @@ import {
   type AgentReasoningEffort,
   type ClaudeReasoningEffort,
 } from './agent-process'
+import { config } from './config'
 import { getTokenSource, listEnabledTokenSourcesByAgent, type TokenSource } from './token-source'
 import { clearRollbackWatchdog } from './rollback-watchdog'
 import {
@@ -137,11 +142,17 @@ const MAX_MIDTURN_ROTATES = 5
  * presenting the session as ready. */
 const CLAUDE_STARTUP_GRACE_MS = 250
 
-/** footer 状态文案:状态词 + 相对时长档位(<30s / <1m / <3m / <5m / <10m / 10m+…)。
- *  档位只在边界变,所以 footer 用自适应 setTimeout 在档位边界 push,不是每秒 tick。
+/** 读取 `[runtime].live_elapsed`;缺 runtime 时回退 bucket(测试 mock 常只 stub claude)。 */
+function liveElapsedMode(): LiveElapsedMode {
+  return config.runtime?.live_elapsed ?? 'bucket'
+}
+
+/** footer 状态文案:状态词 + 耗时标签。
+ *  bucket 模式:相对档位(<30s / <1m / …),只在边界 push;
+ *  second 模式:按秒显示,footer 每 1s push。
  *  见 startFooterTimer / startFooterStatus。*/
 function timedStatus(status: string, startedAt: number): string {
-  return `${status} (${elapsedBucket(Date.now() - startedAt).label})`
+  return `${status} (${liveElapsed(Date.now() - startedAt, liveElapsedMode()).label})`
 }
 
 export class Session {
@@ -170,8 +181,8 @@ export class Session {
   backgroundCard: { messageId: string; cardId: string } | null = null
   /** task_progress 风暴的刷新节流 timer。 */
   private backgroundRefreshTimer: ReturnType<typeof setTimeout> | null = null
-  /** 后台卡自适应 tick:取活跃任务最近的档位边界(cards/background.ts elapsedBucket)
-   *  setTimeout 刷新一次 header 时长标签(<30s/<1m/…),治无 task_progress 的 shell 任务
+  /** 后台卡自适应 tick:bucket 取活跃任务最近档位边界,second 固定 2s。
+   *  setTimeout 刷新一次 header 时长标签,治无 task_progress 的 shell 任务
    *  时长冻结。活卡期间常驻,沉降/迁移时清。见 startBackgroundRefreshTick。 */
   private backgroundRefreshTick: ReturnType<typeof setTimeout> | null = null
   /** openBackgroundCard 进行中标记 —— 防止并发 bg_task 事件在 await sendCard
@@ -687,14 +698,14 @@ export class Session {
       if (stopped) return
       void this.replaceFooterContent(cardId, renderContent(timedStatus(status, startedAt)))
     }
-    // footer 显示「状态词 + 相对档位」(见 timedStatus),档位只在边界变 —— 用自适应
-    // setTimeout 链在下一档位边界 push,不是每秒 tick。setStatus 切换状态也立即 push。
+    // footer 显示「状态词 + 耗时」(见 timedStatus)。bucket 只在档位边界 push;
+    // second 固定 1s。setStatus 切换状态也立即 push。
     // elapsedSec 仍基于 startedAt,供 closeStatusCard 结束时显示总耗时。
     let timer: ReturnType<typeof setTimeout> | null = null
     const scheduleNext = (): void => {
       if (stopped) return
-      const { nextDelayMs } = elapsedBucket(Date.now() - startedAt)
-      timer = setTimeout(() => { render(); scheduleNext() }, nextDelayMs)
+      const { nextDelayMs } = liveElapsed(Date.now() - startedAt, liveElapsedMode())
+      timer = setTimeout(() => { render(); scheduleNext() }, Math.max(1, Math.ceil(nextDelayMs)))
     }
     render()
     scheduleNext()
@@ -1817,7 +1828,7 @@ export class Session {
 
   private async openBackgroundCard(): Promise<void> {
     if (this.backgroundCard) return
-    const card = cards.backgroundLiveCard(this.backgroundTasks)
+    const card = cards.backgroundLiveCard(this.backgroundTasks, Date.now(), liveElapsedMode())
     const messageId = await feishu.sendCard(this.chatId, card)
     if (!messageId) {
       log(`session "${this.sessionName}": background card send failed`)
@@ -1838,26 +1849,29 @@ export class Session {
     this.startBackgroundRefreshTick()
   }
 
-  /** 后台卡 tick:running 任务 header 显示相对档位(见 cards.elapsedBucket),档位
-   *  只在边界变 —— 取所有活跃任务中最近的档位边界,setTimeout 到那时刷新一次再调度
-   *  下一个,不是固定 2s tick(那会无脑刷所有 panel,是后台卡调用大头)。事件驱动的
-   *  scheduleBackgroundRefresh 仍负责详情 diff;本 tick 只补跨档时的时长标签。*/
+  /** 后台卡 tick:running 任务 header 时长标签。
+   *  bucket:取所有活跃任务最近档位边界再刷新(省配额);
+   *  second:固定 2s tick。事件驱动的 scheduleBackgroundRefresh 仍负责详情 diff;
+   *  本 tick 只补无 progress 事件时的时长变化。*/
   private startBackgroundRefreshTick(): void {
     if (this.backgroundRefreshTick) return
     const schedule = (): void => {
       if (!this.backgroundCard || !cards.hasActiveBgTask(this.backgroundTasks)) return
+      const mode = liveElapsedMode()
       const now = Date.now()
       let minDelay = Infinity
       for (const t of this.backgroundTasks) {
         if (cards.isBgTerminal(t)) continue
-        const { nextDelayMs } = elapsedBucket(now - t.startedAt)
-        if (nextDelayMs < minDelay) minDelay = nextDelayMs
+        const delay = mode === 'second'
+          ? LIVE_ELAPSED_SECOND_BACKGROUND_TICK_MS
+          : liveElapsed(now - t.startedAt, mode).nextDelayMs
+        if (delay < minDelay) minDelay = delay
       }
       if (!isFinite(minDelay)) return
       this.backgroundRefreshTick = setTimeout(() => {
         this.refreshBackgroundCardFull()
         schedule()
-      }, minDelay)
+      }, Math.max(1, Math.ceil(minDelay)))
     }
     schedule()
   }
@@ -1886,12 +1900,13 @@ export class Session {
     const handle = this.backgroundCard
     if (!handle) return
     const now = Date.now()
+    const mode = liveElapsedMode()
     for (const t of this.backgroundTasks) {
       if (!this.backgroundDetailAdded.has(t.id)) {
         this.backgroundDetailAdded.add(t.id)
-        void cardkit.addElement(handle.cardId, cards.backgroundTaskPanel(t, now))
+        void cardkit.addElement(handle.cardId, cards.backgroundTaskPanel(t, now, mode))
       } else {
-        void cardkit.replaceElement(handle.cardId, cards.BG_ELEMENTS.panel(t.id), cards.backgroundTaskPanel(t, now))
+        void cardkit.replaceElement(handle.cardId, cards.BG_ELEMENTS.panel(t.id), cards.backgroundTaskPanel(t, now, mode))
       }
     }
     // 同步聊天列表预览(config.summary) —— 建卡后任务增减 / 结算都要反映到预览,
@@ -3040,17 +3055,17 @@ export class Session {
     this.stopFooterStatus(turn)
     turn.footerStatusLabel = status
     turn.footerStatusStartedAt = Date.now()
-    // footer 显示「状态词 + 相对档位」(见 cards/background.ts elapsedBucket),档位
-    // 只在边界变 —— 用自适应 setTimeout 链在下一档位边界 push,不是每秒 tick。
+    // footer 显示「状态词 + 耗时」(见 cards/background.ts liveElapsed)。
+    // bucket 只在档位边界 push;second 固定 1s。
     const render = (): void => {
       if (turn.footerStatusLabel !== status) return
-      const { label } = elapsedBucket(Date.now() - turn.footerStatusStartedAt)
+      const { label } = liveElapsed(Date.now() - turn.footerStatusStartedAt, liveElapsedMode())
       void this.replaceFooterContent(turn.cardId, this.withModel(`${status} (${label})`))
     }
     const scheduleNext = (): void => {
       if (turn.footerStatusLabel !== status) return
-      const { nextDelayMs } = elapsedBucket(Date.now() - turn.footerStatusStartedAt)
-      turn.footerStatusHandle = setTimeout(() => { render(); scheduleNext() }, nextDelayMs)
+      const { nextDelayMs } = liveElapsed(Date.now() - turn.footerStatusStartedAt, liveElapsedMode())
+      turn.footerStatusHandle = setTimeout(() => { render(); scheduleNext() }, Math.max(1, Math.ceil(nextDelayMs)))
     }
     render()
     scheduleNext()


### PR DESCRIPTION
## 问题

上游把活跃 footer / 后台任务 header 的耗时刷新改成了档位制（`<30s` / `<1m` / …），只在档位边界 push，能省 cardkit 配额。部分用户仍希望旧式「按秒」进度文案（如 `45s`），默认档位无法满足。

## 根因

耗时标签与 next tick 只走 `elapsedBucket`，没有可配置的按秒模式；session 定时器 delay 也固定按档位边界计算。

## 修复

- 新增 `[runtime].live_elapsed = "bucket" | "second"`（默认 `bucket`，大小写不敏感；非法值启动失败）
- `liveElapsed(ms, mode)`：`second` 时标签为整秒 `Ns`，footer 约 1s、后台卡约 2s 刷新；`bucket` 保持现有档位行为
- `session` 经 `liveElapsedMode()` 读取配置（兼容测试里不完整的 config mock：`config.runtime?.live_elapsed ?? 'bucket'`）
- README 配置说明 + `src/cards/AGENTS.md` 注明 helper 位置
- 测试：`src/config.test.ts`（默认/接受/拒绝）、`background.test.ts`（second 模式）、`session.test.ts`（second 下 setTimeout delay + 文案）

默认行为不变；需要按秒时在 `~/.config/lodestar/config.toml` 写：

```toml
[runtime]
live_elapsed = "second"
```

改完需重启 daemon。

## 验证

```bash
bun test src/config.test.ts src/cards/background.test.ts
# 含 second-mode session 用例；全量相对 upstream/main 零回归
# upstream/main 全量基线：3 fail（既有 mock/env，与本 PR 无关）
# 本分支全量：同样 3 fail，无新增失败
```

- 分支基于 `upstream/main` @ `403671e`
- 实现刻意留在 `background.ts`（未抽 `format.ts`），减少上游 diff 面